### PR TITLE
Fix #177 - Push disabled inboxes to bottom

### DIFF
--- a/inboxen/tests/test_home.py
+++ b/inboxen/tests/test_home.py
@@ -77,8 +77,8 @@ class HomeViewTestCase(test.TestCase):
         middle = ordered_inboxes[int(len(ordered_inboxes) / 2)]
         middle.flags.pinned = True
 
-        # Finally the least active.
-        least = ordered_inboxes[-1]
+        # Finally the least active (NB: negative indexing isn't supported).
+        least = ordered_inboxes[len(ordered_inboxes)-1]
         least.flags.pinned = True
 
         response = self.client.get(self.get_url())
@@ -109,8 +109,8 @@ class HomeViewTestCase(test.TestCase):
         middle = ordered_inboxes[int(len(ordered_inboxes) / 2)]
         middle.flags.disabled = True
 
-        # Finally the inbox with the least activity.
-        least = ordered_inboxes[-1]
+        # Finally the least active (NB: negative indexing isn't supported).
+        least = ordered_inboxes[len(ordered_inboxes)-1]
         least.flags.disabled = True
 
         # Get the page, they should have been pushed to the second page.

--- a/inboxen/tests/test_home.py
+++ b/inboxen/tests/test_home.py
@@ -66,7 +66,8 @@ class HomeViewTestCase(test.TestCase):
     def test_pinned_first(self):
         # Mark some specific inboxes based on activity. One for most recent, one
         # in the middel and then the least recent.
-        ordered_inboxes = models.Inbox.objects.all().order_by("-last_activity")
+        ordered_inboxes = models.Inbox.objects.all().add_last_activity()
+        ordered_inboxes = ordered_inboxes.order_by("-last_activity")
 
         # Most recent activity
         latest = ordered_inboxes[0]
@@ -97,7 +98,8 @@ class HomeViewTestCase(test.TestCase):
         # Find three inboxes, the inbox with: the most recent activity, least
         # recent activity and then pick one from the middle. This insures that
         # they sink to the bottom but keep their order within the disabled.
-        ordered_inboxes = models.Inbox.objects.all().order_by("-last_activity")
+        ordered_inboxes = models.Inbox.objects.all().add_last_activity()
+        ordered_inboxes = ordered_inboxes.order_by("-last_activity")
 
         # The inbox with the latest activity.
         latest = ordered_inboxes[0]

--- a/inboxen/tests/test_home.py
+++ b/inboxen/tests/test_home.py
@@ -72,14 +72,17 @@ class HomeViewTestCase(test.TestCase):
         # Most recent activity
         latest = ordered_inboxes[0]
         latest.flags.pinned = True
+        latest.save()
 
         # Around (or exactly) the middle in activity.
         middle = ordered_inboxes[int(len(ordered_inboxes) / 2)]
         middle.flags.pinned = True
+        middle.save()
 
         # Finally the least active (NB: negative indexing isn't supported).
         least = ordered_inboxes[len(ordered_inboxes)-1]
         least.flags.pinned = True
+        least.save()
 
         response = self.client.get(self.get_url())
         objs = response.context["page_obj"].object_list[:5]
@@ -89,7 +92,7 @@ class HomeViewTestCase(test.TestCase):
 
         # Check the pinned inboxes are ordered amongst themselves.
         self.assertEqual(
-            [obj.id for o in objs],
+            [obj.id for obj in objs][:3],
             [latest.id, middle.id, least.id]
         )
 
@@ -104,25 +107,31 @@ class HomeViewTestCase(test.TestCase):
         # The inbox with the latest activity.
         latest = ordered_inboxes[0]
         latest.flags.disabled = True
+        latest.save()
 
         # One from the middle
         middle = ordered_inboxes[int(len(ordered_inboxes) / 2)]
         middle.flags.disabled = True
+        middle.save()
 
         # Finally the least active (NB: negative indexing isn't supported).
         least = ordered_inboxes[len(ordered_inboxes)-1]
         least.flags.disabled = True
+        least.save()
 
         # Get the page, they should have been pushed to the second page.
         response = self.client.get(self.get_url() + "2/")
-        objs = response.context["page_obj"].object_list[:5]
+        objs = response.context["page_obj"].object_list[45:]
 
         # Check the last three are disabled
-        self.assertEqual([obj.disabled for o in objs], [0, 0, 1, 1, 1])
+        self.assertEqual(
+            [bool(obj.flags.disabled) for obj in objs],
+            [False, False, True, True, True]
+        )
 
         # Check the three are in order amongst themselves.
         self.assertEqual(
-            [obj.id for o in objs],
+            [obj.id for obj in objs[2:]],
             [latest.id, middle.id, least.id]
         )
 

--- a/inboxen/tests/test_home.py
+++ b/inboxen/tests/test_home.py
@@ -80,7 +80,7 @@ class HomeViewTestCase(test.TestCase):
         # Find three inboxes, the inbox with: the most recent activity, least
         # recent activity and then pick one from the middle. This insures that
         # they sink to the bottom but keep their order within the disabled.
-        ordered_inboxes = models.Inbox.objets.all().order_by("-last_activity")
+        ordered_inboxes = models.Inbox.objects.all().order_by("-last_activity")
 
         # The inbox with the latest activity.
         latest = ordered_inboxes[0]

--- a/inboxen/views/user/home.py
+++ b/inboxen/views/user/home.py
@@ -50,7 +50,7 @@ class UserHomeView(LoginRequiredMixin, generic.ListView):
         if self.request.method != "POST":
             qs = qs.add_last_activity()
             qs = qs.annotate(pinned=Count(Case(When(flags=models.Inbox.flags.pinned, then=1), output_field=IntegerField())))
-            qs = qs.annotate(disabled=Case(When(flags=models.Inbox.flags.disabled, then=1), output_field=IntegerField()))
+            qs = qs.annotate(disabled=Count(Case(When(flags=models.Inbox.flags.disabled, then=1), output_field=IntegerField())))
             qs = qs.order_by("-pinned", "disabled", "-last_activity").select_related("domain")
         return qs
 

--- a/inboxen/views/user/home.py
+++ b/inboxen/views/user/home.py
@@ -50,7 +50,8 @@ class UserHomeView(LoginRequiredMixin, generic.ListView):
         if self.request.method != "POST":
             qs = qs.add_last_activity()
             qs = qs.annotate(pinned=Count(Case(When(flags=models.Inbox.flags.pinned, then=1), output_field=IntegerField())))
-            qs = qs.order_by("-pinned", "-last_activity").select_related("domain")
+            qs = qs.annotate(disabled=Case(When(flags=models.Inbox.flags.disabled, then=1), output_field=IntegerField()))
+            qs = qs.order_by("-pinned", "disabled", "-last_activity").select_related("domain")
         return qs
 
     @search.skip_index_update()


### PR DESCRIPTION
This will fix #177 by annotating the QuerySet with the "disabled" flag and then order by said flag. This will result in the inboxes with the disabled flag being pushed to the bottom of the inbox list. 