### PR TITLE
Fix #194 - Add missing copyright headers

### DIFF
--- a/account/tasks.py
+++ b/account/tasks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 import logging
 from datetime import datetime
 

--- a/blog/__init__.py
+++ b/blog/__init__.py
@@ -1,1 +1,20 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 default_app_config = 'blog.apps.BlogConfig'

--- a/blog/wagtail_hooks.py
+++ b/blog/wagtail_hooks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.contrib.modeladmin.views import CreateView, EditView
 

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,1 +1,20 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 default_app_config = 'cms.apps.CMSConfig'

--- a/cms/apps.py
+++ b/cms/apps.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from __future__ import unicode_literals
 
 from django.apps import AppConfig

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from django.conf import settings
 from django.db import models
 from django.core.urlresolvers import RegexURLResolver, reverse

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from django import template
 
 from cms.utils import app_reverse

--- a/cms/utils.py
+++ b/cms/utils.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 def app_reverse(page, site, viewname, args=None, kwargs=None):
     """Reverse a URL for an app that is behind an AppPage"""
     relative_url = page.reverse(viewname, args=args, kwargs=kwargs)

--- a/cms/views.py
+++ b/cms/views.py
@@ -1,5 +1,23 @@
-from django.http import Http404
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
 
+from django.http import Http404
 
 def user_editing_disabled_view(request):
     raise Http404("User editing disabled")

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from django.conf import settings, urls
 
 from wagtail.wagtailcore import hooks

--- a/inboxen/__init__.py
+++ b/inboxen/__init__.py
@@ -1,1 +1,20 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 default_app_config = 'inboxen.apps.InboxenConfig'

--- a/inboxen/checks.py
+++ b/inboxen/checks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 import os
 import stat
 

--- a/inboxen/tasks.py
+++ b/inboxen/tasks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from datetime import datetime, timedelta
 from importlib import import_module
 import gc

--- a/inboxen/wagtail_hooks.py
+++ b/inboxen/wagtail_hooks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from wagtail.contrib.modeladmin.helpers import PermissionHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 

--- a/liberation/tasks.py
+++ b/liberation/tasks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 import json
 import hashlib
 import logging

--- a/liberation/utils.py
+++ b/liberation/utils.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from StringIO import StringIO
 from email.header import Header
 from email.message import Message

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
 import os
 import sys
 

--- a/router/config/boot.py
+++ b/router/config/boot.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 import logging
 import logging.config
 import os

--- a/tickets/__init__.py
+++ b/tickets/__init__.py
@@ -1,1 +1,20 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 default_app_config = 'tickets.apps.TicketConfig'

--- a/tickets/wagtail_hooks.py
+++ b/tickets/wagtail_hooks.py
@@ -1,3 +1,22 @@
+##
+#    Copyright (C) 2013, 2014, 2015, 2016, 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from tickets import models, views


### PR DESCRIPTION
This fixes issue #194 by adding copyright headers to a any file which was missing it unless the file was empty or a settings/configuration file.