### PR TITLE
Remove "delete" option from certain admin pages #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Pending
 
 * Fix ratelimit warnings in tests (#197)
+* Disable certain actions in the admin interface (e.g. disable deleting Domains (#193))
 
 ### Deploy for 2017-04-14
 

--- a/account/tests/test_username.py
+++ b/account/tests/test_username.py
@@ -26,7 +26,7 @@ from inboxen.tests import utils
 
 class LowerCaseUsernameTestCase(test.TestCase):
     def setUp(self):
-        self.user = factories.UserFactory()
+        self.user = factories.UserFactory(username="isdabizda")
 
     def test_login(self):
         params = {"username": "ISdaBIZda", "password": "123456"}

--- a/inboxen/tests/factories.py
+++ b/inboxen/tests/factories.py
@@ -40,7 +40,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_user_model()
 
-    username = "isdabizda"
+    username = factory.Sequence(lambda n: "isdabizda%d" % n)
     password = "123456"
 
     @classmethod

--- a/inboxen/tests/test_wagtail.py
+++ b/inboxen/tests/test_wagtail.py
@@ -22,7 +22,7 @@ import mock
 from django import test
 from django.core import urlresolvers
 
-from inboxen.tests import factories
+from inboxen.tests import factories, utils
 from inboxen import models
 from inboxen.wagtail_hooks import DomainPermissionHelper, RequestPermissionHelper
 
@@ -38,7 +38,7 @@ class WagtailHooksTestCase(test.TestCase):
         self.domain = factories.DomainFactory()
         self.request = models.Request.objects.create(requester=factories.UserFactory(), amount=100)
 
-        login = self.client.login(username=self.user.username, password="123456")
+        login = self.client.login(username=self.user.username, password="123456", request=utils.MockRequest(self.user))
 
         self.admin_middleware_mock = mock.patch("inboxen.middleware.WagtailAdminProtectionMiddleware", MiddlewareMock)
 

--- a/inboxen/tests/test_wagtail.py
+++ b/inboxen/tests/test_wagtail.py
@@ -1,0 +1,106 @@
+##
+#    Copyright (C) 2017 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+import mock
+
+from django import test
+from django.core import urlresolvers
+
+from inboxen.tests import factories
+from inboxen import models
+from inboxen.wagtail_hooks import DomainPermissionHelper, RequestPermissionHelper
+
+
+class MiddlewareMock(object):
+    pass
+
+
+class WagtailHooksTestCase(test.TestCase):
+    def setUp(self):
+        super(WagtailHooksTestCase, self).setUp()
+        self.user = factories.UserFactory(is_superuser=True)
+        self.domain = factories.DomainFactory()
+        self.request = models.Request.objects.create(requester=factories.UserFactory(), amount=100)
+
+        login = self.client.login(username=self.user.username, password="123456")
+
+        self.admin_middleware_mock = mock.patch("inboxen.middleware.WagtailAdminProtectionMiddleware", MiddlewareMock)
+
+        if not login:
+            raise Exception("Could not log in")
+
+        self.admin_middleware_mock.start()
+
+    def tearDown(self):
+        super(WagtailHooksTestCase, self).tearDown()
+        self.admin_middleware_mock.stop()
+
+    def test_domain_index_allowed(self):
+        url = urlresolvers.reverse("inboxen_domain_modeladmin_index")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_domain_create_allowed(self):
+        url = urlresolvers.reverse("inboxen_domain_modeladmin_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_domain_delete_denied(self):
+        url = urlresolvers.reverse("inboxen_domain_modeladmin_delete", kwargs={"instance_pk": self.domain.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_domain_permission_helper(self):
+        helper = DomainPermissionHelper(models.Domain)
+
+        # check that user_can_create always returns None
+        self.assertEqual(helper.user_can_create(self.user), True)
+
+        # check that user_can_delete_obj always returns None
+        self.assertEqual(helper.user_can_delete_obj(self.user, self.domain), False)
+        # it shouldn't even check args
+        self.assertEqual(helper.user_can_delete_obj(None, None), False)
+
+    def test_request_index_allowed(self):
+        url = urlresolvers.reverse("inboxen_request_modeladmin_index")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_request_create_allowed(self):
+        url = urlresolvers.reverse("inboxen_request_modeladmin_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_delete_denied(self):
+        url = urlresolvers.reverse("inboxen_request_modeladmin_delete", kwargs={"instance_pk": self.request.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_permission_helper(self):
+        helper = RequestPermissionHelper(models.Domain)
+
+        # check that user_can_create always returns None
+        self.assertEqual(helper.user_can_create(self.user), False)
+        # it shouldn't even check args
+        self.assertEqual(helper.user_can_create(None), False)
+
+        # check that user_can_delete_obj always returns None
+        self.assertEqual(helper.user_can_delete_obj(self.user, self.request), False)
+        # it shouldn't even check args
+        self.assertEqual(helper.user_can_delete_obj(None, None), False)

--- a/inboxen/wagtail_hooks.py
+++ b/inboxen/wagtail_hooks.py
@@ -27,11 +27,20 @@ class RequestPermissionHelper(PermissionHelper):
     def user_can_create(self, user):
         return False
 
+    def user_can_delete_obj(self, user, obj):
+        return False
+
+
+class DomainPermissionHelper(PermissionHelper):
+    def user_can_delete_obj(self, user, obj):
+        return False
+
 
 class DomainAdmin(ModelAdmin):
     model = models.Domain
     menu_icon = 'snippet'
     list_display = ("domain", "owner", "enabled")
+    permission_helper_class = DomainPermissionHelper
 
 
 class RequestAdmin(ModelAdmin):

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -276,7 +276,7 @@ class WagtailHooksTestCase(test.TestCase):
 
         self.admin_middleware_mock = mock.patch("inboxen.middleware.WagtailAdminProtectionMiddleware", MiddlewareMock)
 
-        login = self.client.login(username=self.user.username, password="123456")
+        login = self.client.login(username=self.user.username, password="123456", request=utils.MockRequest(self.user))
 
         if not login:
             raise Exception("Could not log in")

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -17,6 +17,8 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
+import mock
+
 from django import test
 from django.core import mail, urlresolvers
 from django.db.models import Max
@@ -30,6 +32,7 @@ from cms.utils import app_reverse
 from inboxen.tests import factories, utils
 from inboxen.utils import override_settings
 from tickets import models
+from tickets.wagtail_hooks import QuestionPermissionHelper
 from tickets.templatetags import tickets_flags
 
 
@@ -54,6 +57,10 @@ class ResponseFactory(factory.django.DjangoModelFactory):
 class MockModel(models.RenderBodyMixin):
     def __init__(self, body):
         self.body = body
+
+
+class MiddlewareMock(object):
+    pass
 
 
 class QuestionViewTestCase(test.TestCase):
@@ -259,3 +266,46 @@ class RenderStatus(test.TestCase):
         self.assertIn(unicode(tickets_flags.STATUS_TO_TAGS[models.Question.NEW]["class"]), result)
 
         self.assertNotEqual(tickets_flags.render_status(models.Question.RESOLVED), result)
+
+
+class WagtailHooksTestCase(test.TestCase):
+    def setUp(self):
+        super(WagtailHooksTestCase, self).setUp()
+        self.user = factories.UserFactory(is_superuser=True)
+        self.question = QuestionFactory()
+
+        self.admin_middleware_mock = mock.patch("inboxen.middleware.WagtailAdminProtectionMiddleware", MiddlewareMock)
+
+        login = self.client.login(username=self.user.username, password="123456")
+
+        if not login:
+            raise Exception("Could not log in")
+
+        self.admin_middleware_mock.start()
+
+    def tearDown(self):
+        super(WagtailHooksTestCase, self).tearDown()
+        self.admin_middleware_mock.stop()
+
+    def test_create_denied(self):
+        url = urlresolvers.reverse("tickets_question_modeladmin_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_denied(self):
+        url = urlresolvers.reverse("tickets_question_modeladmin_delete", kwargs={"instance_pk": self.question.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_permission_helper(self):
+        helper = QuestionPermissionHelper(models.Question)
+
+        # check that user_can_create always returns None
+        self.assertEqual(helper.user_can_create(self.user), False)
+        # it shouldn't even check args
+        self.assertEqual(helper.user_can_create(None), False)
+
+        # check that user_can_delete_obj always returns None
+        self.assertEqual(helper.user_can_delete_obj(self.user, self.question), False)
+        # it shouldn't even check args
+        self.assertEqual(helper.user_can_delete_obj(None, None), False)

--- a/tickets/wagtail_hooks.py
+++ b/tickets/wagtail_hooks.py
@@ -17,9 +17,18 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
+from wagtail.contrib.modeladmin.helpers import PermissionHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from tickets import models, views
+
+
+class QuestionPermissionHelper(PermissionHelper):
+    def user_can_create(self, user):
+        return False
+
+    def user_can_delete_obj(self, user, obj):
+        return False
 
 
 class QuestionAdmin(ModelAdmin):
@@ -27,5 +36,6 @@ class QuestionAdmin(ModelAdmin):
     menu_icon = 'help'
     list_display = ("subject", "author", "status")
     edit_view_class = views.QuestionAdminEditView
+    permission_helper_class = QuestionPermissionHelper
 
 modeladmin_register(QuestionAdmin)


### PR DESCRIPTION
Fixes #193 

Remove delete and create buttons from ModelAdmin views where it makes sense (e.g. we'll never want to add a question via the admin, we don't want to delete domains)

- [x] Tests
- [x] Changelog entry