### PR TITLE
Fix form error handling in tickets app

### DIFF
--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -113,6 +113,17 @@ class QuestionViewTestCase(test.TestCase):
         self.assertEqual(question.author_id, self.user.id)
         self.assertEqual(question.body, "This is the body of my question")
 
+        del params["subject"]
+        response = self.client.post(self.get_url(), params)
+        self.assertEqual(response.status_code, 200)
+
+        maybe_new_question = models.Question.objects.latest("date")
+
+        # there shouldn't be a newer question
+        self.assertEqual(question, maybe_new_question)
+
+
+
 
 class QuestionDetailTestCase(test.TestCase):
     def setUp(self):

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -102,8 +102,8 @@ class QuestionViewTestCase(test.TestCase):
         list_url = app_reverse(self.page, self.site, "tickets-list", kwargs={"status": "closed"})
         self.assertIn(list_url, response.content)
 
-    def test_post(self):
-        params = {"subject": "hello!", "body": "This is the body of my question"}
+    def test_post_form_valid(self):
+        params = {"subject": "Hello!", "body": "This is the body of my question"}
         response = self.client.post(self.get_url(), params)
         question = models.Question.objects.latest("date")
 
@@ -113,16 +113,29 @@ class QuestionViewTestCase(test.TestCase):
         self.assertEqual(question.author_id, self.user.id)
         self.assertEqual(question.body, "This is the body of my question")
 
-        del params["subject"]
-        response = self.client.post(self.get_url(), params)
+    def test_post_form_invalid(self):
+        question_count = models.Question.objects.all().count()
+
+        # subject missing
+        response = self.client.post(self.get_url(), {"body": "This is the body of my question"})
         self.assertEqual(response.status_code, 200)
+        self.assertIn("subject", response.context["form"].errors)
+        self.assertNotIn("body", response.context["form"].errors)
+        self.assertEqual(question_count, models.Question.objects.all().count())
 
-        maybe_new_question = models.Question.objects.latest("date")
+        # body missing
+        response = self.client.post(self.get_url(), {"subject": "Hello!"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("body", response.context["form"].errors)
+        self.assertNotIn("subject", response.context["form"].errors)
+        self.assertEqual(question_count, models.Question.objects.all().count())
 
-        # there shouldn't be a newer question
-        self.assertEqual(question, maybe_new_question)
-
-
+        # missing everything
+        response = self.client.post(self.get_url(), {})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("subject", response.context["form"].errors)
+        self.assertIn("body", response.context["form"].errors)
+        self.assertEqual(question_count, models.Question.objects.all().count())
 
 
 class QuestionDetailTestCase(test.TestCase):
@@ -148,7 +161,7 @@ class QuestionDetailTestCase(test.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.question.render_body(), response.content)
 
-    def test_post(self):
+    def test_post_form_valid(self):
         response = self.client.post(self.get_url(), {"body": "hello"})
         self.assertRedirects(response, self.get_url())
 
@@ -160,8 +173,13 @@ class QuestionDetailTestCase(test.TestCase):
         response = self.client.get(self.get_url())
         self.assertIn(responses[0].render_body(), response.content)
 
+    def test_post_form_invalid(self):
+        response_count = models.Response.objects.all().count()
+
         response = self.client.post(self.get_url(), {})
         self.assertEqual(response.status_code, 200)
+        self.assertIn("body", response.context["form"].errors)
+        self.assertEqual(response_count, models.Response.objects.all().count())
 
 
 class QuestionListTestCase(test.TestCase):

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -150,8 +150,7 @@ class QuestionDetailTestCase(test.TestCase):
 
     def test_post(self):
         response = self.client.post(self.get_url(), {"body": "hello"})
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], self.get_url())
+        self.assertRedirects(response, self.get_url())
 
         responses = self.question.response_set.all()
         self.assertEqual(len(responses), 1)
@@ -160,6 +159,9 @@ class QuestionDetailTestCase(test.TestCase):
 
         response = self.client.get(self.get_url())
         self.assertIn(responses[0].render_body(), response.content)
+
+        response = self.client.post(self.get_url(), {})
+        self.assertEqual(response.status_code, 200)
 
 
 class QuestionListTestCase(test.TestCase):

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -41,6 +41,7 @@ class FormMixin(generic.edit.FormMixin):
         return kwargs
 
     def post(self, request, *args, **kwargs):
+        self.object_list = self.get_queryset()
         form_class = self.get_form_class()
         form = self.get_form(form_class)
 
@@ -69,8 +70,8 @@ class QuestionHomeView(LoginRequiredMixin, generic.ListView, FormMixin):
 
     def get_context_data(self, **kwargs):
         context = super(QuestionHomeView, self).get_context_data(**kwargs)
-        context["open"] = self.get_queryset().open()[:self.paginate_by]
-        context["closed"] = self.get_queryset().closed()[:self.paginate_by]
+        context["open"] = self.object_list.open()[:self.paginate_by]
+        context["closed"] = self.object_list.closed()[:self.paginate_by]
 
         return context
 


### PR DESCRIPTION
A user recently tried to submit a question to our tickets app, but forgot to add a subject. The result was a 500 error, rather than a form error.

This PR fixes that and extends tests to cover this issue.