### PR TITLE
Exclude admin from CSP protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Change error message feeder command gives when inbox does not exit
 * Fix non-ASCII filename handling in attachment download (#206)
+* Remove CSP protection from the Wagtail admin (#219)
 
 ### Deploy for 2017-05-20
 

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -267,6 +267,8 @@ CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = ("'self'",)
 CSP_SCRIPT_SRC = ("'self'",)
 CSP_STYLE_SRC = ("'self'",)
+# TODO https://github.com/wagtail/wagtail/issues/1288
+CSP_EXCLUDE_URL_PREFIXES = ('/admin',)
 
 if DEBUG:
     # local dev made easy


### PR DESCRIPTION
Due to the way Wagtail handles JS, we can't use CSP with it.

Making CMS pages is otherwise a bit difficult (you have to write raw HTML, there are various glitches)