### PR TITLE
[Follow up to #215] Stop requiring manually setting the settings module for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Drop Sqlite support (#214)
 * Remove "view" button from attachments (#202)
 * Stop proxying non-HTTP URIs (e.g. mailto:) (#211)
+* Tests are now run with the test settings module by default
 
 ### Deploy for 2017-05-20
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ cd Inboxen
 pip install -r requirements-dev.txt
 mkdir node_modules
 npm update
+python manage.py collectstatic
 ```
 
 When you've made your changes, remember to run `flake8` against Python files
@@ -51,7 +52,7 @@ you've changed (and `jshint` on JS files) and run unit tests. To run the tests,
 do the following:
 
 ```
-python manage.py test --settings=inboxen.tests.settings
+python manage.py test
 ```
 
 Committing and Branching

--- a/inboxen/tests/settings.py
+++ b/inboxen/tests/settings.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import
 import os
 
+
+# tell settings module to ignore normal config file
 os.environ['INBOXEN_TESTING'] = '1'
 from inboxen.settings import *
+
+# build asserts if need be
+ASSETS_AUTO_BUILD = True
 
 CACHES = {
     "default": {
@@ -10,7 +15,8 @@ CACHES = {
     }
 }
 
-postgres_user = os.environ.get('PG_USER', 'postgres')
+# default to current user
+postgres_user = os.environ.get('PG_USER', os.environ.get('USER'))
 
 SECRET_KEY = "This is a test, you don't need secrets"
 ENABLE_REGISTRATION = True

--- a/manage.py
+++ b/manage.py
@@ -21,8 +21,10 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inboxen.settings")
-
+    if 'test' in sys.argv[1:2]:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inboxen.tests.settings")
+    else:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inboxen.settings")
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
Also, enable auto_build for webassets during tests

Fixes #180