### PR TITLE
Simplify and unify MIME part fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Pass attachment name to template for email view (#229)
 * Change how MIME parts and headers are fetched to be more generic (#109)
-* Search and email view now use the same function (#109)
+* Search and email view now use the same function when walking the MIME tree (#109)
 * Implement a styleguide
 * Remove last vestiges of django-extensions' UUID field (#230)
 * Fix `FutureWarning` being raised by LXML (#232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 * Pass attachment name to template for email view (#229)
+* Change how MIME parts and headers are fetched to be more generic (#109)
 
 ## Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Pass attachment name to template for email view (#229)
 * Change how MIME parts and headers are fetched to be more generic (#109)
+* Search and email view now use the same function (#109)
 * Implement a styleguide
 * Remove last vestiges of django-extensions' UUID field (#230)
 * Fix `FutureWarning` being raised by LXML (#232)

--- a/inboxen/models.py
+++ b/inboxen/models.py
@@ -264,23 +264,23 @@ class PartList(MPTTModel):
     def _content_headers_cache(self):
         data = {}
         part_head = self.header_set.get_many("Content-Type", "Content-Disposition")
-        content_header = part_head.pop("Content-Type", "").split(";", 1)
+        content_header = part_head.pop("Content-Type", u"").split(";", 1)
         data['content_type'] = content_header[0]
-        content_params = content_header[1] if len(content_header) > 1 else ""
+        content_params = content_header[1] if len(content_header) > 1 else u""
 
         if not self.is_leaf_node():
             return data
 
-        dispos = part_head.pop("Content-Disposition", "")
+        dispos = part_head.pop("Content-Disposition", u"")
 
         params = dict(HEADER_PARAMS.findall(content_params))
         params.update(dict(HEADER_PARAMS.findall(dispos)))
 
         # find filename, could be anywhere, could be nothing
-        data["filename"] = params.get("filename") or params.get("name") or ""
+        data["filename"] = params.get("filename") or params.get("name") or u""
 
         # grab charset
-        data["charset"] = params.get("charset", "utf-8")
+        data["charset"] = params.get("charset", u"utf-8")
 
         return data
 

--- a/inboxen/search.py
+++ b/inboxen/search.py
@@ -20,9 +20,10 @@
 import re
 
 from django.core import exceptions
-from django.utils import encoding
 
 from watson import search
+
+from inboxen.utils.email import unicode_damnit
 
 
 HEADER_PARAMS = re.compile(r'([a-zA-Z0-9]+)=["\']?([^"\';=]+)["\']?[;]?')
@@ -77,7 +78,7 @@ class EmailSearchAdapter(search.SearchAdapter):
             )
             subject = subject[0]
 
-            return encoding.smart_text(subject.data, errors='replace')
+            return unicode_damnit(subject.data)
         except IndexError:
             return u""
 
@@ -89,7 +90,7 @@ class EmailSearchAdapter(search.SearchAdapter):
         except IndexError:
             return u""
 
-        return encoding.smart_text(body.data[:self.trunc_to_size], encoding=self.get_body_charset(obj, body), errors='replace')
+        return unicode_damnit(body.data[:self.trunc_to_size], self.get_body_charset(obj, body))
 
     def get_content(self, obj):
         """Fetch all text/* bodies for obj, reading up to `trunc_to_size` bytes"""
@@ -102,10 +103,10 @@ class EmailSearchAdapter(search.SearchAdapter):
             if remains <= 0:
                 break
             elif remains < body.size:
-                data.append(encoding.smart_text(body.data[:remains], encoding=self.get_body_charset(obj, body), errors='replace'))
+                data.append(unicode_damnit(body.data[:remains], self.get_body_charset(obj, body))
                 break
             else:
-                data.append(encoding.smart_text(body.data, encoding=self.get_body_charset(obj, body), errors='replace'))
+                data.append(unicode_damnit(body.data, self.get_body_charset(obj, body)))
 
         return u"\n".join(data)
 
@@ -119,7 +120,7 @@ class EmailSearchAdapter(search.SearchAdapter):
                 header__name__name="From",
                 header__part__email__id=obj.id,
             )[0]
-            from_header = encoding.smart_text(from_header.data, errors='replace')
+            from_header = unicode_damnit(from_header.data)
         except IndexError:
             from_header = u""
 

--- a/inboxen/search.py
+++ b/inboxen/search.py
@@ -17,17 +17,12 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-import re
-
 from django.core import exceptions
 from django.db.models import Q
 
 from watson import search
 
 from inboxen.utils.email import unicode_damnit
-
-
-HEADER_PARAMS = re.compile(r'([a-zA-Z0-9]+)=["\']?([^"\';=]+)["\']?[;]?')
 
 
 def find_body(part):

--- a/inboxen/search.py
+++ b/inboxen/search.py
@@ -25,6 +25,8 @@ from watson import search
 from inboxen.utils.email import unicode_damnit, find_bodies
 
 def choose_body(parts):
+    """Given a list of sibling MIME parts, choose the one with a content_type
+    of "text/plain", if it exists"""
     if len(parts) == 1:
         return unicode_damnit(parts[0].body.data, parts[0].charset)
     elif len(parts) > 1:
@@ -58,7 +60,8 @@ class EmailSearchAdapter(search.SearchAdapter):
 
     def get_description(self, obj):
         """Fetch first text/plain body for obj, reading up to `trunc_to_size`
-        bytes """
+        bytes
+        """
         bodies = find_bodies(obj.get_parts()).next()
 
         if bodies is not None:
@@ -68,7 +71,8 @@ class EmailSearchAdapter(search.SearchAdapter):
 
     def get_content(self, obj):
         """Fetch all text/plain bodies for obj, reading up to `trunc_to_size`
-        bytes"""
+        bytes and excluding those that would not be displayed
+        """
         data = []
         size = 0
         for parts in find_bodies(obj.get_parts()):

--- a/inboxen/templates/inboxen/inbox/email.html
+++ b/inboxen/templates/inboxen/inbox/email.html
@@ -65,23 +65,8 @@
 <div id="email-body">{{ body }}</div>
 {% endfor %}
 <br />
-<strong>{% trans "Attachments" %}</strong>:<br />
-<div class="form">
-{% for attachment in attachments %}
-{% if attachment.is_leaf_node %}
-    <div class="col-sm-4 col-md-3 col-lg-2">
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <div class="btn-group btn-group-justified" role="group">
-                    <a href="{% url 'email-attachment' attachmentid=attachment.id %}" class="btn btn-default">
-                        {% trans "Download" %}
-                    </a>
-                </div>
-            </div>
-            <div class="panel-body wrap-words">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
-        </div>
-    </div>
-{% endif %}
-{% endfor %}
+<strong>{% trans "Attachments" %}</strong>
+<div>
+{% include "inboxen/includes/attachment.html" with attachment=attachments %}
 </div>
 {% endblock %}

--- a/inboxen/templates/inboxen/includes/attachment.html
+++ b/inboxen/templates/inboxen/includes/attachment.html
@@ -1,0 +1,20 @@
+{# Copyright (c) 2017 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
+{% load i18n %}
+{% if attachment.is_leaf_node %}
+    <div class="col-sm-4 col-md-3 col-lg-2">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <div class="btn-group btn-group-justified" role="group">
+                    <a href="{% url 'email-attachment' attachmentid=attachment.id %}" class="btn btn-default">
+                        {% trans "Download" %}
+                    </a>
+                </div>
+            </div>
+            <div class="panel-body wrap-words">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
+        </div>
+    </div>
+{% else %}
+    {% for child in attachment.get_children %}
+        {% include "inboxen/includes/attachment.html" with attachment=child %}
+    {% endfor %}
+{% endif %}

--- a/inboxen/tests/example_emails.py
+++ b/inboxen/tests/example_emails.py
@@ -1231,174 +1231,6 @@ i3E4=3D&ea.client.id=3D1422"/>
 ------=_Part_29748710_445134290.1448020924829--
 """
 
-
-EXAMPLE_DIGEST = """Content-Type: multipart/mixed; boundary="===============1488510984=="
-MIME-Version: 1.0
-From: centos-announce-request@centos.org
-Subject: CentOS-announce Digest, Vol 109, Issue 3
-To: centos-announce@centos.org
-Reply-To: centos-announce@centos.org
-Date: Mon, 10 Mar 2014 12:00:04 +0000
-Message-ID: <mailman.12.1394452804.11046.centos-announce@centos.org>
-X-BeenThere: centos-announce@centos.org
-X-Mailman-Version: 2.1.9
-Precedence: list
-List-Id: "CentOS announcements \(security and general\) will be posted to
- this list." <centos-announce.centos.org>
-List-Unsubscribe:
- <http://lists.centos.org/mailman/listinfo/centos-announce>,
- <mailto:centos-announce-request@centos.org?subject=unsubscribe>
-List-Archive: <http://lists.centos.org/pipermail/centos-announce>
-List-Post: <mailto:centos-announce@centos.org>
-List-Help: <mailto:centos-announce-request@centos.org?subject=help>
-List-Subscribe: <http://lists.centos.org/mailman/listinfo/centos-announce>,
- <mailto:centos-announce-request@centos.org?subject=subscribe>
-Sender: centos-announce-bounces@centos.org
-Errors-To: centos-announce-bounces@centos.org
-
-
---===============1488510984==
-Content-Type: text/plain; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Description: CentOS-announce Digest, Vol 109, Issue 3
-
-Send CentOS-announce mailing list submissions to
-        centos-announce@centos.org
-
-To subscribe or unsubscribe via the World Wide Web, visit
-        http://lists.centos.org/mailman/listinfo/centos-announce
-or, via email, send a message with subject or body 'help' to
-        centos-announce-request@centos.org
-
-You can reach the person managing the list at
-        centos-announce-owner@centos.org
-
-When replying, please edit your Subject line so it is more specific
-than "Re: Contents of CentOS-announce digest..."
-
---===============1488510984==
-Content-Type: text/plain; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Description: Today's Topics (2 messages)
-
-Today's Topics:
-
-   1. CEBA-2014:0262  CentOS 6 qemu-kvm Update (Johnny Hughes)
-   2. CEBA-2014:0264  CentOS 6 libtirpc Update (Johnny Hughes)
-
---===============1488510984==
-Content-Type: multipart/digest; boundary="===============0249781194=="
-MIME-Version: 1.0
-
-
---===============0249781194==
-Content-Type: message/rfc822
-MIME-Version: 1.0
-
-From: Johnny Hughes <johnny@centos.org>
-Precedence: list
-MIME-Version: 1.0
-To: centos-announce@centos.org
-Date: Mon, 10 Mar 2014 11:21:06 +0000
-Reply-To: centos@centos.org
-Message-ID: <20140310112106.GA24758@n04.lon1.karan.org>
-Content-Type: text/plain; charset=us-ascii
-Subject: [CentOS-announce] CEBA-2014:0262  CentOS 6 qemu-kvm Update
-Message: 1
-
-
-CentOS Errata and Bugfix Advisory 2014:0262
-
-Upstream details at : https://rhn.redhat.com/errata/RHBA-2014-0262.html
-
-The following updated files have been uploaded and are currently
-syncing to the mirrors: ( sha256sum Filename )
-
-i386:
-46164fd539f764d60217ca6193928d37e8ab3ae1be81ae833b15f866de5fedd0  qemu-guest-agent-0.12.1.2-2.415.el6_5.5.i686.rpm
-
-x86_64:
-aed574e07f0992175f9777787991b664d1cf72c8e0d563e7d58185282ce3f8c4  qemu-guest-agent-0.12.1.2-2.415.el6_5.5.x86_64.rpm
-0885b34016bdc113d1dff172d9835aec6ae4dc5919243ec7cb707cbebc607527  qemu-img-0.12.1.2-2.415.el6_5.5.x86_64.rpm
-01109b5adab7bf10e5b81c670838160e74a60ee75561e971fca378773ff3941a  qemu-kvm-0.12.1.2-2.415.el6_5.5.x86_64.rpm
-7e2e6e07951b8611473551f983eabaf60e3a649e8a04cc933ea47aa3b94f0479  qemu-kvm-tools-0.12.1.2-2.415.el6_5.5.x86_64.rpm
-
-Source:
-9abd731cd3600b76507b3c1911fc89464c6f29d37b04f349d3a684812e66f402  qemu-kvm-0.12.1.2-2.415.el6_5.5.src.rpm
-
-
-
---
-Johnny Hughes
-CentOS Project { http://www.centos.org/ }
-irc: hughesjr, #centos@irc.freenode.net
-
-
-
---===============0249781194==
-Content-Type: message/rfc822
-MIME-Version: 1.0
-
-From: Johnny Hughes <johnny@centos.org>
-Precedence: list
-MIME-Version: 1.0
-To: centos-announce@centos.org
-Date: Mon, 10 Mar 2014 11:21:45 +0000
-Reply-To: centos@centos.org
-Message-ID: <20140310112145.GA24853@n04.lon1.karan.org>
-Content-Type: text/plain; charset=us-ascii
-Subject: [CentOS-announce] CEBA-2014:0264  CentOS 6 libtirpc Update
-Message: 2
-
-
-CentOS Errata and Bugfix Advisory 2014:0264
-
-Upstream details at : https://rhn.redhat.com/errata/RHBA-2014-0264.html
-
-The following updated files have been uploaded and are currently
-syncing to the mirrors: ( sha256sum Filename )
-
-i386:
-0232079882c8a0f3cdd00417b0fdfc45fdb2f2066d7bd35a2b127658be6f8d94  libtirpc-0.2.1-6.el6_5.1.i686.rpm
-0fc6cd31c479c01b3bd4d3a6c62fd04ec8a4429708ef10e41633b628f0771fb4  libtirpc-devel-0.2.1-6.el6_5.1.i686.rpm
-
-x86_64:
-0232079882c8a0f3cdd00417b0fdfc45fdb2f2066d7bd35a2b127658be6f8d94  libtirpc-0.2.1-6.el6_5.1.i686.rpm
-8fbe3e9cc0f83dd10b6a34c6d37695dccf9968c74177f8cb676467dbd82678fe  libtirpc-0.2.1-6.el6_5.1.x86_64.rpm
-0fc6cd31c479c01b3bd4d3a6c62fd04ec8a4429708ef10e41633b628f0771fb4  libtirpc-devel-0.2.1-6.el6_5.1.i686.rpm
-9fae583a5e8b1520f5a4982348fa00ce602b0d76e7a01a560e92314f66609385  libtirpc-devel-0.2.1-6.el6_5.1.x86_64.rpm
-
-Source:
-1ab0d65c11a4a51a88c7d03884e8f052745fc6778f276731f574ad510dd58185  libtirpc-0.2.1-6.el6_5.1.src.rpm
-
-
-
---
-Johnny Hughes
-CentOS Project { http://www.centos.org/ }
-irc: hughesjr, #centos@irc.freenode.net
-
-
-
---===============0249781194==--
-
---===============1488510984==
-Content-Type: text/plain; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Description: Digest Footer
-
-_______________________________________________
-CentOS-announce mailing list
-CentOS-announce@centos.org
-http://lists.centos.org/mailman/listinfo/centos-announce
-
---===============1488510984==--
-"""
-
-
 EXAMPLE_ALT = """Return-Path: <newsletter@gog.com>
 Delivered-To: <moggers87@thewarof1812.moggers.co.uk>
 DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=gog.com; s=klucz;
@@ -1677,7 +1509,408 @@ v id=3D"_t"></div>
 
 """
 
+EXAMPLE_DIGEST = """Delivered-To: example@example.com
+Received: by 10.227.0.129 with SMTP id 1csp102594wbb;
+        Fri, 14 Feb 2014 04:01:13 -0800 (PST)
+X-Received: by 10.229.171.8 with SMTP id f8mr12089678qcz.13.1392379272257;
+        Fri, 14 Feb 2014 04:01:12 -0800 (PST)
+Return-Path: <centos-announce-bounces@centos.org>
+Received: from mail.centos.org (mail.centos.org. [72.26.200.202]) by
+ mx.google.com with ESMTP id fy9si3575001qab.69.2014.02.14.04.01.11 for
+ <multiple recipients>; Fri, 14 Feb 2014 04:01:12 -0800 (PST)
+Received-SPF: pass (google.com: best guess record for domain of
+ centos-announce-bounces@centos.org designates 72.26.200.202 as permitted
+ sender) client-ip=72.26.200.202;
+Authentication-Results: mx.google.com; spf=pass (google.com: best guess
+ record for domain of centos-announce-bounces@centos.org designates
+ 72.26.200.202 as permitted sender)
+ smtp.mail=centos-announce-bounces@centos.org
+Received: from mail.centos.org (voxeldev.centos.org [127.0.0.1])
+	by mail.centos.org (Postfix) with ESMTP id A864A27E7FB8;
+	Fri, 14 Feb 2014 12:00:11 +0000 (UTC)
+Content-Type: multipart/mixed; boundary="===============0954800312=="
+MIME-Version: 1.0
+From: centos-announce-request@centos.org
+Subject: CentOS-announce Digest, Vol 108, Issue 9
+To: centos-announce@centos.org
+Reply-To: centos-announce@centos.org
+Date: Fri, 14 Feb 2014 12:00:04 +0000
+Message-ID: <mailman.12.1392379204.22573.centos-announce@centos.org>
+X-BeenThere: centos-announce@centos.org
+X-Mailman-Version: 2.1.9
+Precedence: list
+List-Id: "CentOS announcements \(security and general\) will be posted to
+ this list." <centos-announce.centos.org>
+List-Unsubscribe:
+ <http://lists.centos.org/mailman/listinfo/centos-announce>,
+ <mailto:centos-announce-request@centos.org?subject=unsubscribe>
+List-Archive: <http://lists.centos.org/pipermail/centos-announce>
+List-Post: <mailto:centos-announce@centos.org>
+List-Help: <mailto:centos-announce-request@centos.org?subject=help>
+List-Subscribe: <http://lists.centos.org/mailman/listinfo/centos-announce>,
+	<mailto:centos-announce-request@centos.org?subject=subscribe>
+Sender: centos-announce-bounces@centos.org
+Errors-To: centos-announce-bounces@centos.org
+X-Evolution-Source: 1373376044.1477.3@orpheus
 
+
+--===============0954800312==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Description: CentOS-announce Digest, Vol 108, Issue 9
+Content-Transfer-Encoding: 8bit
+
+Send CentOS-announce mailing list submissions to
+	centos-announce@centos.org
+
+To subscribe or unsubscribe via the World Wide Web, visit
+	http://lists.centos.org/mailman/listinfo/centos-announce
+or, via email, send a message with subject or body 'help' to
+	centos-announce-request@centos.org
+
+You can reach the person managing the list at
+	centos-announce-owner@centos.org
+
+When replying, please edit your Subject line so it is more specific
+than "Re: Contents of CentOS-announce digest..."
+
+--===============0954800312==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Description: Today's Topics (6 messages)
+Content-Transfer-Encoding: 8bit
+
+Today's Topics:
+
+   1. CESA-2014:0163 Important CentOS 5 kvm Update (Johnny Hughes)
+   2. CESA-2014:0164 Moderate CentOS 6 mysql Update (Johnny Hughes)
+   3. CEEA-2014:0165  CentOS 5 kdelibs Update (Johnny Hughes)
+   4. CESA-2014:0175 Important CentOS 6 piranha Update (Johnny Hughes)
+   5. CESA-2014:0174 Important CentOS 5 piranha Update (Johnny Hughes)
+   6. CentOS at Scale 12x (Johnny Hughes)
+
+--===============0954800312==
+Content-Type: multipart/digest; boundary="===============1423313159=="
+MIME-Version: 1.0
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: centos-announce@centos.org
+Date: Wed, 12 Feb 2014 19:33:17 +0000
+Reply-To: centos@centos.org
+Message-ID: <20140212193317.GA28103@chakra.karan.org>
+Content-Type: text/plain; charset=us-ascii
+Subject: [CentOS-announce] CESA-2014:0163 Important CentOS 5 kvm Update
+Message: 1
+Content-Transfer-Encoding: 8bit
+
+
+CentOS Errata and Security Advisory 2014:0163 Important
+
+Upstream details at : https://rhn.redhat.com/errata/RHSA-2014-0163.html
+
+The following updated files have been uploaded and are currently
+syncing to the mirrors: ( sha256sum Filename )
+
+
+x86_64:
+1d288a530ed89adada97ed8979e5f129848a4051ad16481edcaf7befdb8a3838  kmod-kvm-83-266.el5.centos.1.x86_64.rpm
+3e80eaa38d2a7132193023018122f8b93bdd87eecde7b5e2e4ac7e98ebf01a2b  kmod-kvm-debug-83-266.el5.centos.1.x86_64.rpm
+19ab38c1f03a8e931582250ad4ad40a7a439b74deae2b9c13af99fa11b794aa0  kvm-83-266.el5.centos.1.x86_64.rpm
+ab2e5b49a4e9a6fba2f1b19f6348793147bad0d504351866d557ab2d75b9c9f8  kvm-qemu-img-83-266.el5.centos.1.x86_64.rpm
+1ab605f9bd17ba9a61a421f6132bea55873cd98573461b71e03f3b4713df98ef  kvm-tools-83-266.el5.centos.1.x86_64.rpm
+
+Source:
+a3d2506a7e8b2055a99acad6b19eb65da556d0dc8b87f4b8c183c2883c972149  kvm-83-266.el5.centos.1.src.rpm
+
+
+
+--
+Johnny Hughes
+CentOS Project { http://www.centos.org/ }
+irc: hughesjr, #centos@irc.freenode.net
+
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: centos-announce@centos.org
+Date: Wed, 12 Feb 2014 19:48:34 +0000
+Reply-To: centos@centos.org
+Message-ID: <20140212194834.GA28170@n04.lon1.karan.org>
+Content-Type: text/plain; charset=us-ascii
+Subject: [CentOS-announce] CESA-2014:0164 Moderate CentOS 6 mysql Update
+Message: 2
+Content-Transfer-Encoding: 8bit
+
+
+CentOS Errata and Security Advisory 2014:0164 Moderate
+
+Upstream details at : https://rhn.redhat.com/errata/RHSA-2014-0164.html
+
+The following updated files have been uploaded and are currently
+syncing to the mirrors: ( sha256sum Filename )
+
+i386:
+5d6f7adf4447f82150918dcf44cba6dedbdc327d44472c4abc88cc5460367dd8  mysql-5.1.73-3.el6_5.i686.rpm
+8b9c123dea1c781a9a568ba4e5580191b55bc9e67be330acc0c296fd6e77a730  mysql-bench-5.1.73-3.el6_5.i686.rpm
+505ddde78c99e2627ca79b5de754089cf6eb896258d90b67480ed6de0f017a7a  mysql-devel-5.1.73-3.el6_5.i686.rpm
+7d3c9182f5768824bdce6b3ef78509f6abb8df8dfe04ae60b9183679de3f3e6b  mysql-embedded-5.1.73-3.el6_5.i686.rpm
+3dc30e192d66ea39186dc156736feca34feff092ecdad0d5e0e2c09ca0fb051d  mysql-embedded-devel-5.1.73-3.el6_5.i686.rpm
+771ce477aeee96d7bb09e4bfe69fea1dc19d05d0836d30c9fe2d8e9a8f627cc7  mysql-libs-5.1.73-3.el6_5.i686.rpm
+6fb982c618a977e2b91b0ab01f576762d980a8dfd715366888d48f711144cd46  mysql-server-5.1.73-3.el6_5.i686.rpm
+d7ba139d4159d7110fd5ee742d3362382aa9861dcacb70fedde4c5bd76a6d69e  mysql-test-5.1.73-3.el6_5.i686.rpm
+
+x86_64:
+d2270a13c54e1bb437abd21c52ff31ce3e8ea52371caee115ac695c0a154d563  mysql-5.1.73-3.el6_5.x86_64.rpm
+01eff9e169e46c4a61783c63a24e812dadd2de5ff53ae17c06f7e9a6b4d1ee4a  mysql-bench-5.1.73-3.el6_5.x86_64.rpm
+505ddde78c99e2627ca79b5de754089cf6eb896258d90b67480ed6de0f017a7a  mysql-devel-5.1.73-3.el6_5.i686.rpm
+234377c2b83ad539bd4a70af47abaf2b6e8cd3467a59fd6d24808d1da88f4ad1  mysql-devel-5.1.73-3.el6_5.x86_64.rpm
+7d3c9182f5768824bdce6b3ef78509f6abb8df8dfe04ae60b9183679de3f3e6b  mysql-embedded-5.1.73-3.el6_5.i686.rpm
+3be25b9328385f0ab22f7fc86da0bf240a5317f77841eca66809fea2fd23e03d  mysql-embedded-5.1.73-3.el6_5.x86_64.rpm
+3dc30e192d66ea39186dc156736feca34feff092ecdad0d5e0e2c09ca0fb051d  mysql-embedded-devel-5.1.73-3.el6_5.i686.rpm
+52f7f372730c29c5531577d937d9f3d4008a09079091d52afee0894055f4504f  mysql-embedded-devel-5.1.73-3.el6_5.x86_64.rpm
+771ce477aeee96d7bb09e4bfe69fea1dc19d05d0836d30c9fe2d8e9a8f627cc7  mysql-libs-5.1.73-3.el6_5.i686.rpm
+ae6801e7cada3f97307d85cbd7e80dd996bc2460dc58932d1c8c3f0124b04e85  mysql-libs-5.1.73-3.el6_5.x86_64.rpm
+5ec01f451863b047918668c5334f94531769eb33b87d1cc5820f6cce9e77ef97  mysql-server-5.1.73-3.el6_5.x86_64.rpm
+07b2d0d9218da171bbfbdb909b15cc8eaa21b1a159d0e4f6c77034f9f087a8f9  mysql-test-5.1.73-3.el6_5.x86_64.rpm
+
+Source:
+e8f5b352bf4f89affedcd643442e3498a4c5c3fedfad73917905b6e9d5fead04  mysql-5.1.73-3.el6_5.src.rpm
+
+
+
+--
+Johnny Hughes
+CentOS Project { http://www.centos.org/ }
+irc: hughesjr, #centos@irc.freenode.net
+
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: centos-announce@centos.org
+Date: Thu, 13 Feb 2014 16:52:55 +0000
+Reply-To: centos@centos.org
+Message-ID: <20140213165255.GA22586@chakra.karan.org>
+Content-Type: text/plain; charset=us-ascii
+Subject: [CentOS-announce] CEEA-2014:0165  CentOS 5 kdelibs Update
+Message: 3
+Content-Transfer-Encoding: 8bit
+
+
+CentOS Errata and Enhancement Advisory 2014:0165
+
+Upstream details at : https://rhn.redhat.com/errata/RHEA-2014-0165.html
+
+The following updated files have been uploaded and are currently
+syncing to the mirrors: ( sha256sum Filename )
+
+i386:
+03c0c18ec6538eb035bb80e5ac0acd9ace7e0b4007025e00351cf83655ef201d  kdelibs-3.5.4-29.el5.centos.i386.rpm
+df066a23a2f2f7180f7f5f5d51e9eded293a14a513a6c707b68ef50a409b71e0  kdelibs-apidocs-3.5.4-29.el5.centos.i386.rpm
+8328f31c793c3c797fec026576d5052b3db78b7d24a89f4f412546761a343e0c  kdelibs-devel-3.5.4-29.el5.centos.i386.rpm
+
+x86_64:
+03c0c18ec6538eb035bb80e5ac0acd9ace7e0b4007025e00351cf83655ef201d  kdelibs-3.5.4-29.el5.centos.i386.rpm
+1222400236af581fec934fc0f17b9d2fc9fe8448806f325c6cec9fb6018ab114  kdelibs-3.5.4-29.el5.centos.x86_64.rpm
+5814db3fa705456ff2f0a39109c77ad56aed26fb761320d5ee5c4e3f4a318bad  kdelibs-apidocs-3.5.4-29.el5.centos.x86_64.rpm
+8328f31c793c3c797fec026576d5052b3db78b7d24a89f4f412546761a343e0c  kdelibs-devel-3.5.4-29.el5.centos.i386.rpm
+86df9f000a39f6b310580996502b4e2792b174adcb1c9f2a72f6158ed649e7f1  kdelibs-devel-3.5.4-29.el5.centos.x86_64.rpm
+
+Source:
+4a617d61320c1abc3de9e44e786ba8e6dc6c19e5cc49d2ce92bbd63d0339dd3d  kdelibs-3.5.4-29.el5.centos.src.rpm
+
+
+
+--
+Johnny Hughes
+CentOS Project { http://www.centos.org/ }
+irc: hughesjr, #centos@irc.freenode.net
+
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: centos-announce@centos.org
+Date: Thu, 13 Feb 2014 20:05:42 +0000
+Reply-To: centos@centos.org
+Message-ID: <20140213200542.GA46343@n04.lon1.karan.org>
+Content-Type: text/plain; charset=us-ascii
+Subject: [CentOS-announce] CESA-2014:0175 Important CentOS 6 piranha Update
+Message: 4
+Content-Transfer-Encoding: 8bit
+
+
+CentOS Errata and Security Advisory 2014:0175 Important
+
+Upstream details at : https://rhn.redhat.com/errata/RHSA-2014-0175.html
+
+The following updated files have been uploaded and are currently
+syncing to the mirrors: ( sha256sum Filename )
+
+i386:
+4d4241930e9d10070344dbb6d9883796f53e34614cb8a0fb105aa75f8c5095be  piranha-0.8.6-4.el6_5.2.i686.rpm
+
+x86_64:
+1fbd986c4b4f2aef9f7294bbcaf82f6eabfad8f0819d1201dfe131ae63aa680b  piranha-0.8.6-4.el6_5.2.x86_64.rpm
+
+Source:
+f17264a1495ab17d935f0e272c2206fc53474e2bc302e88441da6d4dde38cf60  piranha-0.8.6-4.el6_5.2.src.rpm
+
+
+
+--
+Johnny Hughes
+CentOS Project { http://www.centos.org/ }
+irc: hughesjr, #centos@irc.freenode.net
+
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: centos-announce@centos.org
+Date: Thu, 13 Feb 2014 20:20:56 +0000
+Reply-To: centos@centos.org
+Message-ID: <20140213202056.GA778@chakra.karan.org>
+Content-Type: text/plain; charset=us-ascii
+Subject: [CentOS-announce] CESA-2014:0174 Important CentOS 5 piranha Update
+Message: 5
+Content-Transfer-Encoding: 8bit
+
+
+CentOS Errata and Security Advisory 2014:0174 Important
+
+Upstream details at : https://rhn.redhat.com/errata/RHSA-2014-0174.html
+
+The following updated files have been uploaded and are currently
+syncing to the mirrors: ( sha256sum Filename )
+
+i386:
+cf98137c77e69d87b14092c435f50fde5bfc1576eb8daa7ea4bdc6a9fc7d30db  piranha-0.8.4-26.el5_10.1.i386.rpm
+
+x86_64:
+cf56574753c2eaf7ea586da76332094da6524c9cb165fbe4ce110c7699d23fdb  piranha-0.8.4-26.el5_10.1.x86_64.rpm
+
+Source:
+2ca2c83fda1a19014d171ace62f5e856afca2853fb7b7f2098859cd17e6f22ed  piranha-0.8.4-26.el5_10.1.src.rpm
+
+
+
+--
+Johnny Hughes
+CentOS Project { http://www.centos.org/ }
+irc: hughesjr, #centos@irc.freenode.net
+
+
+
+--===============1423313159==
+Content-Type: message/rfc822
+MIME-Version: 1.0
+
+From: Johnny Hughes <johnny@centos.org>
+Precedence: list
+MIME-Version: 1.0
+To: CentOS-Announce <centos-announce@centos.org>
+Date: Thu, 13 Feb 2014 14:42:39 -0600
+Reply-To: centos@centos.org
+Message-ID: <52FD2E3F.7040603@centos.org>
+Content-Type: multipart/signed; micalg=pgp-sha1;
+	protocol="application/pgp-signature";
+	boundary="AvGQ06Sm2IBgNpfTV5qpg9tKusc5IJtD9"
+Subject: [CentOS-announce] CentOS at Scale 12x
+Message: 6
+
+This is an OpenPGP/MIME signed message (RFC 4880 and 3156)
+--AvGQ06Sm2IBgNpfTV5qpg9tKusc5IJtD9
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+Several members of the CentOS team will be at Scale 12x
+(http://bit.ly/1hEH6t5) in Los Angeles, California on February 21st to
+23nd, 2014.
+
+CentOS will be part of the "Infrastructure.Next at Scale" event (
+http://bit.ly/1irKWUm ) event that happens on Friday (21st), and we will
+have the following talk there:
+http://bit.ly/1g2voUB
+
+We will be at the Red Hat Community booth/table on both Saturday and
+Sunday (22nd and 23rd) with free swag (teeshirts, stickers, etc).
+
+We will have a Birds of a Feather session, details of which will be
+provided at the table/booth when finalized.
+
+Finally, we will also have a talk titled "CentOS Project Q&A Forum"
+(http://bit.ly/1bQ5rVS) on Sunday (23rd).
+
+If you are in the Los Angeles area, please stop by and see us at Scale
+12x !!!
+
+Thanks,
+Johnny Hughes
+
+
+--AvGQ06Sm2IBgNpfTV5qpg9tKusc5IJtD9
+Content-Type: application/pgp-signature; name="signature.asc"
+Content-Description: OpenPGP digital signature
+Content-Disposition: attachment; filename="signature.asc"
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.14 (GNU/Linux)
+
+iEYEARECAAYFAlL9LkcACgkQTKkMgmrBY7NDAgCeJicd6G/WLvulJvuYxdwPQUG8
+FCcAn30+5yjvFItIlaikVElS2RIces9w
+=KsAo
+-----END PGP SIGNATURE-----
+
+--AvGQ06Sm2IBgNpfTV5qpg9tKusc5IJtD9--
+
+
+--===============1423313159==--
+
+--===============0954800312==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Description: Digest Footer
+Content-Transfer-Encoding: 8bit
+
+_______________________________________________
+CentOS-announce mailing list
+CentOS-announce@centos.org
+http://lists.centos.org/mailman/listinfo/centos-announce
+
+--===============0954800312==--
+
+"""
+
+# same as EXAMPLE_DIGEST, except its been forwarded as a message/rfc822
 EXAMPLE_SIGNED_FORWARDED_DIGEST = """Message-ID: <1448059000.4758.0.camel@example.com>
 Subject: [Fwd: CentOS-announce Digest, Vol 108, Issue 9]
 From: Matt Molyneaux <example@example.com>

--- a/inboxen/tests/example_emails.py
+++ b/inboxen/tests/example_emails.py
@@ -70,6 +70,17 @@ p {color: #ffffff;background:transparent url(<a href="http://cdn-images.mailchim
 
 BODILESS_BODY = """<p>Click the link below to confirm your subscription to Updates of Loathing:</p><br><a href="http://tinyletter.com/asym/confirm?id=uuid">Subscribe me to Updates of Loathing</a>"""
 
+EXAMPLE_PREMIME_EMAIL = """From: test@example.com
+To: test@example.com
+Subject: My Subject
+
+Hi,
+
+How are you?
+
+Thanks,
+Test
+"""
 
 # example email that was causing issue #47
 EXAMPLE_PREMAILER_BROKEN_CSS = """Return-Path: <bounces@server8839.e-activist.com>

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -416,13 +416,13 @@ class AttachmentTestCase(test.TestCase):
 class UtilityTestCase(test.TestCase):
     def test_is_unicode(self):
         string = "Hey there!"
-        self.assertTrue(isinstance(email_utils._unicode_damnit(string), unicode))
+        self.assertTrue(isinstance(email_utils.unicode_damnit(string), unicode))
 
     def test_unicode_passthrough(self):
         already_unicode = u"€"
 
         # if this doesn't passthrough, it will error
-        email_utils._unicode_damnit(already_unicode, "ascii", "strict")
+        email_utils.unicode_damnit(already_unicode, "ascii", "strict")
 
     def test_clean_html_no_body(self):
         email = {"display_images": True}
@@ -438,5 +438,5 @@ class UtilityTestCase(test.TestCase):
 
     def test_invalid_charset(self):
         text = "Växjö"
-        self.assertEqual(email_utils._unicode_damnit(text, "utf-8"), u"Växjö")
-        self.assertEqual(email_utils._unicode_damnit(text, "unicode"), u"V\ufffd\ufffdxj\ufffd\ufffd")
+        self.assertEqual(email_utils.unicode_damnit(text, "utf-8"), u"Växjö")
+        self.assertEqual(email_utils.unicode_damnit(text, "unicode"), u"V\ufffd\ufffdxj\ufffd\ufffd")

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -34,6 +34,7 @@ from inboxen.tests.example_emails import (
     EXAMPLE_ALT,
     EXAMPLE_DIGEST,
     EXAMPLE_PREMAILER_BROKEN_CSS,
+    EXAMPLE_PREMIME_EMAIL,
     EXAMPLE_SIGNED_FORWARDED_DIGEST,
     METALESS_BODY,
 )
@@ -372,6 +373,19 @@ class RealExamplesTestCase(test.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["email"]["bodies"]), 1)
         self.assertNotIn("Part of this message could not be parsed - it may not display correctly", response.content)
+
+    def test_premime(self):
+        self.msg = mail.MailRequest("", "", "", EXAMPLE_PREMIME_EMAIL)
+        make_email(self.msg, self.inbox)
+        self.email = models.Email.objects.get()
+
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(self.email.parts.all().count(), 1)
+        self.assertEqual(len(response.context["email"]["bodies"]), 1)
+        self.assertEqual(response.context["email"]["bodies"][0], "<pre>Hi,\n\nHow are you?\n\nThanks,\nTest\n</pre>")
+
 
 
 class AttachmentTestCase(test.TestCase):

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -337,7 +337,7 @@ class RealExamplesTestCase(test.TestCase):
         self.assertEqual(response.status_code, 200)
 
         # this email should display all leaves
-        leaf_part_count = len([i for i in self.email.get_parts() if i.is_leaf_node()])
+        leaf_part_count = len([i for i in self.email.parts.all() if i.is_leaf_node()])
         self.assertEqual(len(response.context["email"]["bodies"]), leaf_part_count)
 
     def test_signed_forwarded_digest(self):
@@ -348,7 +348,7 @@ class RealExamplesTestCase(test.TestCase):
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
 
-        leaf_part_count = len([i for i in self.email.get_parts() if i.is_leaf_node()])
+        leaf_part_count = len([i for i in self.email.parts.all() if i.is_leaf_node()])
         self.assertEqual(leaf_part_count, 12)
         self.assertEqual(len(response.context["email"]["bodies"]), 1)
         self.assertEqual(response.context["email"]["bodies"][0], "<pre>Hello\n</pre>")

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -338,7 +338,7 @@ class RealExamplesTestCase(test.TestCase):
         self.assertEqual(response.status_code, 200)
 
         # this email should display all leaves
-        leaf_part_count = len([i for i in self.email.parts.all() if i.is_leaf_node()])
+        leaf_part_count = len([i for i in self.email.parts.all() if i.is_leaf_node() and i.content_type != "application/pgp-signature"])
         self.assertEqual(len(response.context["email"]["bodies"]), leaf_part_count)
 
     def test_signed_forwarded_digest(self):

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -467,7 +467,7 @@ class UtilityTestCase(test.TestCase):
         part.body.data = BADLY_ENCODED_BODY
 
         with mock.patch("inboxen.utils.email.messages") as msg_mock:
-            returned_body = email_utils._render_body(None, email, [part])
+            returned_body = email_utils.render_body(None, email, [part])
             self.assertEqual(msg_mock.error.call_count, 1)
         self.assertIsInstance(returned_body, unicode)
 

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -54,7 +54,7 @@ class InboxenPremailer(Premailer):
         return ""
 
 
-def _unicode_damnit(data, charset="utf-8", errors="replace"):
+def unicode_damnit(data, charset="utf-8", errors="replace"):
     """Makes doubley sure that we can turn the database's binary typees into
     unicode objects
     """
@@ -137,7 +137,7 @@ def _clean_html_body(request, email, body, charset):
         link.attrib["rel"] = "noreferrer"
 
     # finally, export to unicode
-    body = _unicode_damnit(etree.tostring(html_tree), charset)
+    body = unicode_damnit(etree.tostring(html_tree), charset)
     return safestring.mark_safe(body)
 
 
@@ -178,9 +178,9 @@ def _render_body(request, email, attachments):
     # finally, set the body to something
     if plain_message:
         if plain:
-            body = _unicode_damnit(plain.body.data, plain.charset)
+            body = unicode_damnit(plain.body.data, plain.charset)
         elif len(attachments) == 1:
-            body = _unicode_damnit(attachments[0].body.data, attachments[0].charset)
+            body = unicode_damnit(attachments[0].body.data, attachments[0].charset)
         else:
             body = u""
     else:
@@ -188,7 +188,7 @@ def _render_body(request, email, attachments):
             body = _clean_html_body(request, email, str(html.body.data), html.charset)
         except (etree.LxmlError, ValueError) as exc:
             if plain is not None and len(plain.body.data) > 0:
-                body = _unicode_damnit(plain.body.data, plain.charset)
+                body = unicode_damnit(plain.body.data, plain.charset)
             else:
                 body = u""
 

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -210,9 +210,14 @@ def find_bodies(request, email, part):
     try:
         main, sub = part.content_type.split("/", 1)
     except ValueError:
+        # if there isn't a content type and it's the root part, then this is a
+        # plain email
         if part.is_leaf_node() and part.get_level() == 0:
             email["bodies"] = [_render_body(request, email, [part])]
+        # whether or not this is the root part, return now as there's nothing
+        # left to process
         return
+
     if part.parent:
         parent_main, parent_sub = part.parent.content_type.split("/", 1)
     else:
@@ -220,12 +225,20 @@ def find_bodies(request, email, part):
 
     if main == "multipart":
         if sub == "alternative":
+            # multipart/alternatives should be choden by _render_body based on
+            # user and request time options, as well as validity of those parts
             email["bodies"].append(_render_body(request, email, part.get_children()))
             return
         for child in part.get_children():
+            # other multiple parts need their sub trees walked before we can
+            # render anything
             find_bodies(request, email, child)
     elif part.parent and part.parent.content_type == "multipart/digest":
+        # we must be a message/rfc822, check that our child is a text/ part and
+        # there is only one
         if len(part.get_children()) == 1 and part.get_children()[0].content_type.startswith("text/"):
             email["bodies"].append(_render_body(request, email, part.get_children()))
     elif part.is_leaf_node() and main == "text" and sub in ["html", "plain"]:
+        # we've somehow come to a leaf node, if we're a text/plain or text/html
+        # part, render it
         email["bodies"].append(_render_body(request, email, [part]))

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -238,6 +238,11 @@ def find_bodies(request, email, part):
         # there is only one
         if len(part.get_children()) == 1 and part.get_children()[0].content_type.startswith("text/"):
             email["bodies"].append(_render_body(request, email, part.get_children()))
+        elif part.get_children()[0].content_type == "multipart/signed":
+            # sometimes there are signed messages
+            for child in part.get_children()[0].get_children():
+                if child.is_leaf_node() and  child.content_type.startswith("text/"):
+                    email["bodies"].append(_render_body(request, email, [child]))
     elif part.is_leaf_node() and main == "text" and sub in ["html", "plain"]:
         # we've somehow come to a leaf node, if we're a text/plain or text/html
         # part, render it

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -143,7 +143,6 @@ def _clean_html_body(request, email, body, charset):
 
 def render_body(request, email, attachments):
     """Updates `email` with the correct body"""
-    # avoid circular imports
     plain_message = True
     html = None
     plain = None
@@ -177,9 +176,10 @@ def render_body(request, email, attachments):
 
     # finally, set the body to something
     if plain_message:
-        if plain:
+        if plain is not None:
             body = unicode_damnit(plain.body.data, plain.charset)
         elif len(attachments) == 1:
+            # non-MIME email, only "part" must be plain text
             body = unicode_damnit(attachments[0].body.data, attachments[0].charset)
         else:
             body = u""
@@ -198,6 +198,8 @@ def render_body(request, email, attachments):
             _log.exception(msg, extra={"request": request})
 
     if plain_message:
+        # if this is a plain text body, escape any HTML and wrap it in <pre>
+        # tags
         body = html_utils.escape(body)
         body = u"<pre>{}</pre>".format(body)
         body = safestring.mark_safe(body)

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -225,7 +225,7 @@ def find_bodies(request, email, part):
         for child in part.get_children():
             find_bodies(request, email, child)
     elif part.parent and part.parent.content_type == "multipart/digest":
-        if len(part.get_children()) == 1:
+        if len(part.get_children()) == 1 and part.get_children()[0].content_type.startswith("text/"):
             email["bodies"].append(_render_body(request, email, part.get_children()))
     elif part.is_leaf_node() and main == "text" and sub in ["html", "plain"]:
         email["bodies"].append(_render_body(request, email, [part]))

--- a/inboxen/views/inbox/attachment.py
+++ b/inboxen/views/inbox/attachment.py
@@ -33,10 +33,10 @@ __all__ = ["AttachmentDownloadView"]
 class AttachmentDownloadView(LoginRequiredMixin, generic.detail.BaseDetailView):
     def get_object(self):
         qs = models.PartList.objects.select_related('body')
-        qs = qs.filter(email__flags=~models.Email.flags.deleted)
+        qs = qs.filter(email__flags=~models.Email.flags.deleted, email__inbox__user=self.request.user)
 
         try:
-            return qs.get(id=self.kwargs["attachmentid"], email__inbox__user=self.request.user)
+            return qs.get(id=self.kwargs["attachmentid"])
         except models.PartList.DoesNotExist:
             raise Http404
 
@@ -44,27 +44,18 @@ class AttachmentDownloadView(LoginRequiredMixin, generic.detail.BaseDetailView):
         # build the Content-Disposition header
         disposition = ["attachment"]
 
-        headers = self.object.header_set.get_many("Content-Type", "Content-Disposition")
-        content_type = headers.pop("Content-Type", u"text/plain").encode("utf-8").split(";", 1)
-        dispos = headers.pop("Content-Disposition", u"").encode("utf-8")
-
-        try:
-            params = dict(HEADER_PARAMS.findall(content_type[1]))
-        except IndexError:
-            params = {}
-        params.update(dict(HEADER_PARAMS.findall(dispos)))
-
-        if "filename" in params:
-            disposition.append("filename=\"{0}\"".format(params["filename"]))
-        elif "name" in params:
-            disposition.append("filename=\"{0}\"".format(params["name"]))
+        if self.object.filename:
+            disposition.append("filename=\"{0}\"".format(self.object.filename.encode("utf8")))
 
         disposition = "; ".join(disposition)
 
-        if "charset" in params:
-            content_type = "{0}; charset={1}".format(content_type[0], params["charset"])
+        if self.object.content_type:
+            content_type = "{0}; charset={1}".format(
+                self.object.content_type.encode("utf8"),
+                self.object.charset.encode("utf8"),
+            )
         else:
-            content_type = content_type[0]
+            content_type = "application/octet-stream"
 
         # make header object
         data = self.object.body.data or ""

--- a/inboxen/views/inbox/attachment.py
+++ b/inboxen/views/inbox/attachment.py
@@ -24,7 +24,6 @@ from braces.views import LoginRequiredMixin
 
 from inboxen import models
 
-HEADER_PARAMS = re.compile(r'([a-zA-Z0-9]+)=["\']?([^"\';=]+)["\']?[;]?')
 HEADER_CLEAN = re.compile(r'\s+')
 
 __all__ = ["AttachmentDownloadView"]

--- a/inboxen/views/inbox/email.py
+++ b/inboxen/views/inbox/email.py
@@ -120,12 +120,12 @@ class EmailView(LoginRequiredMixin, generic.DetailView):
             email_dict["ask_images"] = False
 
         # iterate over MIME parts
-        attachments = self.object.get_parts()
+        root_part = self.object.get_parts()
 
         email_dict["bodies"] = []
         email_dict["has_images"] = False
 
-        find_bodies(self.request, email_dict, attachments[:1])
+        find_bodies(self.request, email_dict, root_part)
 
         for body in email_dict["bodies"]:
             assert isinstance(body, unicode), "body is %r" % type(body)
@@ -133,7 +133,7 @@ class EmailView(LoginRequiredMixin, generic.DetailView):
         context = super(EmailView, self).get_context_data(**kwargs)
         context.update({
             "email": email_dict,
-            "attachments": attachments,
+            "attachments": root_part,
             "headersfetchall": headers_fetch_all,
         })
 

--- a/inboxen/views/inbox/email.py
+++ b/inboxen/views/inbox/email.py
@@ -28,7 +28,7 @@ from braces.views import LoginRequiredMixin
 from watson import search
 
 from inboxen import models
-from inboxen.utils.email import find_bodies
+from inboxen.utils.email import find_bodies, render_body
 
 
 __all__ = ["EmailView"]
@@ -125,10 +125,7 @@ class EmailView(LoginRequiredMixin, generic.DetailView):
         email_dict["bodies"] = []
         email_dict["has_images"] = False
 
-        find_bodies(self.request, email_dict, root_part)
-
-        for body in email_dict["bodies"]:
-            assert isinstance(body, unicode), "body is %r" % type(body)
+        email_dict["bodies"] = [render_body(self.request, email_dict, parts) for parts in find_bodies(root_part)]
 
         context = super(EmailView, self).get_context_data(**kwargs)
         context.update({


### PR DESCRIPTION
Simplify and unify how MIME parts and their Content-* headers are fetched.

The number of database queries for viewing an email has remained the same, but the code should be less confusing and found in one place.

Also fixes #109 by making both search and email viewing use the same function for fetching parts to be "displayed".