### PR TITLE
Fix LXML warning about find

### DIFF
--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -89,8 +89,8 @@ def _clean_html_body(request, email, body, charset):
             break
 
     try:
-        # check there's a body and header for premailer
-        if html_tree.find("body"):
+        # check there's a body for premailer
+        if html_tree.find("body") is not None:
             html_tree = InboxenPremailer(html_tree).transform()
     except Exception as exc:
         # Yeah, a pretty wide catch, but Premailer likes to throw up everything and anything


### PR DESCRIPTION
If an element has no children, then it will appear falsey. While LXML
shows no sign of changing this odd behaviour, this form is more explicit
about what we're actually looking for.

[This answer on SO has a few more details](https://stackoverflow.com/a/24893800)

Fixes #232