### PR TITLE
Fix corner case in find_bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+* Fix some corner cases in `inboxen.utils.emails.find_bodies` (#243)
+
 ## Releases
 
 ### Deploy for 2017-08-16

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -280,3 +280,18 @@ def find_bodies(part):
         # part is a leaf node and has a content type that we can display
         yield [part]
         return
+
+
+def print_tree(part, func=lambda x: str(x)):
+    """Pretty print a Mime tree
+
+    For debugging emails
+
+    func should be a callable that accepts a PartList object as its only
+    argument and returns a string
+    """
+    indent = "\t" * part.get_level()
+    print "{}{}".format(indent, func(part))
+
+    for child in part.get_children():
+        print_tree(child, func)


### PR DESCRIPTION
`inboxen.utils.email.find_bodies` was making assumptions about MIME parts with `text/` content types.

* Refactored `find_bodies`, including putting the check for a valid leaf node in its own function
* A test to make sure `find_bodies` is being strict with leaf nodes, even when presented with an invalid MIME tree
* A debug function that can print a MIME tree - no tests because it's only a development tools
* Refactored the code that deals with `multipart/digest` emails, hopefully making our intentions clearer

Fixes #234