### PR TITLE
Increase default inbox length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Calculate `new` & `with_inboxes` via aggregate
 * Update to the latest Salmon (#233)
 * Properly remove Wagtail as a dependency (#254)
+* Increase default Inbox length (#226)
 
 ## Releases
 

--- a/inboxen/config_spec.ini
+++ b/inboxen/config_spec.ini
@@ -16,7 +16,7 @@ site_name = string(default="LazyAdmin.com's Inboxen")
 source_link = string(default="https://github.com/Inboxen/Inboxen")
 time_zone = string(default="UTC")
 [inbox]
-inbox_length = integer(default=5)
+inbox_length = integer(default=6)
 min_inbox_for_request = integer(default=10)
 request_number = integer(default=500)
 [tasks]


### PR DESCRIPTION
Some people want to use their inboxes as usernames (hopefully not for a
forum) and 6 characters is usually the lower limit.

Fxies #226