### PR TITLE
Stats fix

### DIFF
--- a/inboxen/tasks.py
+++ b/inboxen/tasks.py
@@ -30,6 +30,7 @@ from django.core import mail
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.db.models import Avg, Case, Count, F, Max, Min, StdDev, Sum, When, IntegerField
+from django.db.models.functions import Coalesce
 
 from pytz import utc
 from watson import search as watson_search
@@ -56,22 +57,22 @@ def statistics():
     one_day_ago = datetime.now(utc) - timedelta(days=1)
     user_aggregate = {
         "count": Count("id"),
-        "new": Sum(Case(When(date_joined__gte=one_day_ago, then=1), output_field=IntegerField())),
-        "with_inboxes": Sum(Case(When(inbox__isnull=False, then=1), output_field=IntegerField())),
-        "oldest_user": Min("date_joined"),
-        "inbox_count__avg": Avg("inbox_count"),
-        "inbox_count__sum": Sum("inbox_count"),
-        "inbox_count__min": Min("inbox_count"),
-        "inbox_count__max": Max("inbox_count"),
-        "inbox_count__stddev": StdDev("inbox_count"),
+        "new": Coalesce(Sum(Case(When(date_joined__gte=one_day_ago, then=1), output_field=IntegerField())), 0),
+        "with_inboxes": Coalesce(Sum(Case(When(inbox__isnull=False, then=1), output_field=IntegerField())), 0),
+        "oldest_user_joined": Min("date_joined"),
+        "inbox_count__avg": Coalesce(Avg("inbox_count"), 0),
+        "inbox_count__sum": Coalesce(Sum("inbox_count"), 0),
+        "inbox_count__min": Coalesce(Min("inbox_count"), 0),
+        "inbox_count__max": Coalesce(Max("inbox_count"), 0),
+        "inbox_count__stddev": Coalesce(StdDev("inbox_count"), 0),
     }
 
     inbox_aggregate = {
-        "email_count__avg": Avg("email_count"),
-        "email_count__sum": Sum("email_count"),
-        "email_count__min": Min("email_count"),
-        "email_count__max": Max("email_count"),
-        "email_count__stddev": StdDev("email_count"),
+        "email_count__avg": Coalesce(Avg("email_count"), 0),
+        "email_count__sum": Coalesce(Sum("email_count"), 0),
+        "email_count__min": Coalesce(Min("email_count"), 0),
+        "email_count__max": Coalesce(Max("email_count"), 0),
+        "email_count__stddev": Coalesce(StdDev("email_count"), 0),
     }
 
     # collect user and inbox stats

--- a/inboxen/templates/inboxen/stats.html
+++ b/inboxen/templates/inboxen/stats.html
@@ -34,10 +34,12 @@
                 <th>{% trans "New users today" %}</th>
                 <td>{{ object.users.new|intcomma }}</td>
             </tr>
+            {% if object.users.oldest_user %}
             <tr>
                 <th>{% trans "Oldest user account" %}</th>
-                <td>{{ object.users.oldest_user }}</td>
+                <td>{{ object.users.oldest_user_joined }}</td>
             </tr>
+            {% endif %}
         </table>
     </div>
     <div class="col-xs-12 col-md-4">

--- a/inboxen/templates/inboxen/stats.html
+++ b/inboxen/templates/inboxen/stats.html
@@ -68,7 +68,7 @@
                 <td>{{ object.inboxes.inbox_count__avg|floatformat:2 }}</td>
             </tr>
             <tr>
-                <th>{% trans "Highest number of inboxes per user" %}</th>
+                <th>{% trans "Highest number of inboxes for one user" %}</th>
                 <td>{{ object.inboxes.inbox_count__max|intcomma }}</td>
             </tr>
         </table>
@@ -95,7 +95,7 @@
                 <td>{{ object.emails.email_count__avg|floatformat:2 }}</td>
             </tr>
             <tr>
-                <th>{% trans "Highest number of emails per inbox" %}</th>
+                <th>{% trans "Highest number of emails in one inbox" %}</th>
                 <td>{{ object.emails.email_count__max|intcomma }}</td>
             </tr>
             <tr>

--- a/inboxen/tests/test_tasks.py
+++ b/inboxen/tests/test_tasks.py
@@ -32,18 +32,30 @@ from inboxen.utils import override_settings
 
 
 class StatsTestCase(test.TestCase):
-    """Test flag tasks"""
-    # only testing that it doesn't raise an exception atm
     def test_no_exceptions(self):
         tasks.statistics.delay()
 
         # run a second time, make sure fetching last stat doesn't cause errors
         tasks.statistics.delay()
 
+    def test_all_zeroes(self):
+        tasks.statistics.delay()
+        stats = models.Statistic.objects.get()
+        for key, value in stats.users.items():
+            if key in ["oldest_user_joined"]:
+                continue
+            self.assertEqual(value, 0, key)
+
+        for key, value in stats.inboxes.items():
+            self.assertEqual(value, 0, key)
+
+        for key, value in stats.emails.items():
+            self.assertEqual(value, 0, key)
+
     def test_running_total(self):
         tasks.statistics.delay()
         stats = models.Statistic.objects.get()
-        self.assertEqual(stats.emails["email_count__sum"], None)
+        self.assertEqual(stats.emails["email_count__sum"], 0)
         self.assertEqual(stats.emails["running_total"], 0)
 
         stats.delete()


### PR DESCRIPTION
A few things that were wrong:

* Sometimes a stat can be 0, but this will be `None` unless we use `Coalesce`
* Don't disable oldest user if there is none (happens on new installs, or when new stats have not been )
* Deduplicate user counting