### PR TITLE
Switch UsernameChangeForm from Form to ModelForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Prevent storing NULL in char and text fields (#274)
 * Update to the latest release of Salmon
+* Make sure user creation and username change forms use the same validation (#281)
 
 ## Releases
 

--- a/account/forms.py
+++ b/account/forms.py
@@ -193,7 +193,7 @@ class UsernameChangeForm(PlaceHolderMixin, forms.ModelForm):
 
         return username
 
-    def clean_new_username2(self):
+    def clean_username2(self):
         username1 = self.cleaned_data.get('username')
         username2 = self.cleaned_data.get('username2')
         if username1 and username2:

--- a/account/forms.py
+++ b/account/forms.py
@@ -172,35 +172,31 @@ class SettingsForm(forms.Form):
         self.profile.save(update_fields=["flags", "prefered_domain"])
 
 
-class UsernameChangeForm(PlaceHolderMixin, forms.Form):
+class UsernameChangeForm(PlaceHolderMixin, forms.ModelForm):
     """Change username"""
-    new_username1 = forms.CharField(label=_("New username"))
-    new_username2 = forms.CharField(label=_("Repeat new username"))
+    username2 = forms.CharField(label=_("Repeat new username"))
 
-    def __init__(self, request, *args, **kwargs):
-        self.user = request.user
-        super(UsernameChangeForm, self).__init__(*args, **kwargs)
+    class Meta:
+        model = get_user_model()
+        fields = ["username"]
+        labels = {"username": _("New username")}
+        help_texts = {"username": _("Letters, numbers, and the symbols @/./+/-/_ are allowed.")}
 
-    def clean_new_username1(self):
-        username = self.cleaned_data.get('new_username1')
+    def clean_username(self):
+        username = self.cleaned_data["username"]
 
         validator = validators.ProhibitNullCharactersValidator()
         validator(username)
 
         if get_user_model().objects.filter(username__iexact=username).exists():
-            raise forms.ValidationError(_("This username is already taken"))
+            raise exceptions.ValidationError(_("A user with that username already exists."), code='duplicate_username')
 
         return username
 
     def clean_new_username2(self):
-        username1 = self.cleaned_data.get('new_username1')
-        username2 = self.cleaned_data.get('new_username2')
+        username1 = self.cleaned_data.get('username')
+        username2 = self.cleaned_data.get('username2')
         if username1 and username2:
             if username1 != username2:
                 raise forms.ValidationError(_("The two username fields don't match."))
         return username2
-
-    def save(self):
-        username = self.cleaned_data["new_username1"]
-        self.user.username = username
-        self.user.save(update_fields=["username"])

--- a/account/tests/test_settings.py
+++ b/account/tests/test_settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##
 #    Copyright (C) 2014 Jessica Tallon & Matt Molyneaux
 #
@@ -117,31 +118,32 @@ class UsernameChangeTestCase(test.TestCase):
         return urlresolvers.reverse("user-username")
 
     def test_form_bad_data(self):
-        request = utils.MockRequest(self.user)
-
         params = {"new_username1": self.user.username, "new_username2": self.user.username}
-        form = UsernameChangeForm(request, data=params)
+        form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
 
         params = {"new_username1": self.user.username + "1", "new_username2": self.user.username}
-        form = UsernameChangeForm(request, data=params)
+        form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
 
         params = {"new_username1": "username\x00", "new_username2": "username\x00"}
-        form = UsernameChangeForm(request, data=params)
+        form = UsernameChangeForm(data=params)
+        self.assertFalse(form.is_valid())
+
+        params = {"new_username1": "usernameß", "new_username2": "usernameß"}
+        form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
 
     def test_form_good_data(self):
         username = self.user.username
 
-        params = {"new_username1": self.user.username + "1", "new_username2": self.user.username + "1"}
-        request = utils.MockRequest(self.user)
-        form = UsernameChangeForm(request, data=params)
+        params = {"username": self.user.username + "1", "username2": self.user.username + "1"}
+        form = UsernameChangeForm(data=params)
 
         self.assertTrue(form.is_valid())
         form.save()
 
-        new_user = get_user_model().objects.get(pk=form.user.pk)
+        new_user = get_user_model().objects.get(pk=form.instance.pk)
         self.assertEqual(new_user.username, username + "1")
 
     def test_get(self):

--- a/account/tests/test_settings.py
+++ b/account/tests/test_settings.py
@@ -118,21 +118,27 @@ class UsernameChangeTestCase(test.TestCase):
         return urlresolvers.reverse("user-username")
 
     def test_form_bad_data(self):
-        params = {"new_username1": self.user.username, "new_username2": self.user.username}
+        params = {"username": self.user.username, "username2": self.user.username}
         form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["username"], [u"A user with that username already exists."])
 
-        params = {"new_username1": self.user.username + "1", "new_username2": self.user.username}
-        form = UsernameChangeForm(data=params)
-        self.assertFalse(form.is_valid())
 
-        params = {"new_username1": "username\x00", "new_username2": "username\x00"}
+        params = {"username": self.user.username + "1", "username2": self.user.username}
         form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["username2"], [u"The two username fields don't match."])
 
-        params = {"new_username1": "usernameß", "new_username2": "usernameß"}
+        params = {"username": "username\x00".decode(), "username2": "username\x00".decode()}
         form = UsernameChangeForm(data=params)
         self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["username"], [u"Null characters are not allowed."])
+
+        params = {"username": "usernameß".decode("utf-8"), "username2": "usernameß".decode("utf-8")}
+        form = UsernameChangeForm(data=params)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["username"],
+            [u"Enter a valid username. This value may contain only English letters, numbers, and @/./+/-/_ characters."])
 
     def test_form_good_data(self):
         username = self.user.username

--- a/account/tests/test_username.py
+++ b/account/tests/test_username.py
@@ -58,15 +58,13 @@ class LowerCaseUsernameTestCase(test.TestCase):
         self.assertTrue(form.is_valid())
 
     def test_change_fail(self):
-        params = {"new_username1": "ISDABIZDA", "new_username2": "ISDABIZDA"}
-        request = utils.MockRequest(self.user)
-        form = forms.UsernameChangeForm(request, data=params)
+        params = {"username": "ISDABIZDA", "username2": "ISDABIZDA"}
+        form = forms.UsernameChangeForm(data=params)
 
         self.assertFalse(form.is_valid())
 
     def test_change_pass(self):
-        params = {"new_username1": "hello1", "new_username2": "hello1"}
-        request = utils.MockRequest(self.user)
-        form = forms.UsernameChangeForm(request, data=params)
+        params = {"username": "hello1", "username2": "hello1"}
+        form = forms.UsernameChangeForm(data=params)
 
         self.assertTrue(form.is_valid())

--- a/account/views/settings.py
+++ b/account/views/settings.py
@@ -51,11 +51,6 @@ class UsernameChangeView(LoginRequiredMixin, SudoMixin, generic.FormView):
     success_url = reverse_lazy("user-settings")
     template_name = "account/username.html"
 
-    def get_form_kwargs(self, **kwargs):
-        kwargs = super(UsernameChangeView, self).get_form_kwargs(**kwargs)
-        kwargs.setdefault("request", self.request)
-        return kwargs
-
     def form_valid(self, form, *args, **kwargs):
         form.save()
         return super(UsernameChangeView, self).form_valid(form=form, *args, **kwargs)


### PR DESCRIPTION
This means that field validators will be used (as happens with the
UserCreationForm)

Fixes #281