### PR TITLE
Replace Bootstrap font choices with system defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Make sure user creation and username change forms use the same validation (#281)
 * Handle attachment name overflow properly (#273)
 * Update log config to include rate limit
+* Use system fonts to avoid issues with bad substitutions of named fonts (#294)
 
 ## Releases
 

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -1,8 +1,14 @@
-// override font vars
+// bootstrap/font awesome stuff
 $icon-font-path: "../../thirdparty/font-awesome/fonts/";
 $fa-font-path: "../../thirdparty/font-awesome/fonts/";
 $icon-font-name: "fontawesome-webfont";
 $icon-font-svg-id: "fontawesomeregular";
+
+// replace bootstrap's default font choices to OS font choices
+$font-family-sans-serif:  sans-serif;
+$font-family-serif:       serif;
+$font-family-monospace:   monospace;
+
 @import "bootstrap-sass/assets/stylesheets/bootstrap";
 @import "font-awesome/scss/font-awesome.scss";
 


### PR DESCRIPTION
Fixes #294 

Before:

![screenshot from 2018-01-16 17-54-17](https://user-images.githubusercontent.com/1490673/35003949-69f19c60-fae6-11e7-8b5b-c6a12a60b9f2.png)

After:

![screenshot from 2018-01-16 17-54-58](https://user-images.githubusercontent.com/1490673/35003948-69bedd70-fae6-11e7-96b1-dc73767874fd.png)

Tested on Firefox, Epiphany, and Chromium.
