### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending
 
+* Improve keyboard accessibility on home and inbox pages (#278)
 
 ## Releases
 

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -20,6 +20,7 @@ $font-family-monospace:   monospace;
  */
 
 $profile-margin: 10px;
+$honeydew-button-size: 1em;
 
 html {
     position: relative;
@@ -157,8 +158,17 @@ body {
 }
 
 .email-buttons, .inbox-options {
+    text-align: right;
+
     .close {
         margin: 5px;
+        display: inline-block;
+        float: none;
+    }
+
+    .fa-fw {
+        height: $honeydew-button-size;
+        width: $honeydew-button-size;
     }
 }
 

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -80,12 +80,22 @@ body {
             padding: $table-cell-padding;
         }
 
-        &:hover {
+        & > a.clickable {
+            &:hover, &:focus-within, &:focus {
+                & > div {
+                    text-decoration: underline;
+                }
+            }
+        }
+
+        &:hover, &:focus-within, &:focus {
             background-color: $table-bg-hover;
         }
 
-        &.title:hover, &.inbox-edit-form-row:hover, &.empty-message:hover, &.more-questions:hover {
-            background-color: initial;
+        &.title, &.inbox-edit-form-row, &.empty-message, &.more-questions {
+            &:hover, &:focus-within, &:focus {
+                background-color: initial;
+            }
         }
     }
 
@@ -117,7 +127,7 @@ body {
 #unified {
     background-color: $state-warning-bg;
 
-    &:hover {
+    &:hover, &:focus-within, &:focus {
         background-color: darken($state-warning-bg, 5%);
     }
 }

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -205,6 +205,10 @@ a.soon {
     &:focus ~ .navbar-toggle {
         background-color: $navbar-default-toggle-hover-bg;
     }
+
+    @media (min-width: $screen-sm-min) {
+        display: none;
+    }
 }
 
 .navbar-toggle {

--- a/inboxen/templates/inboxen/includes/email_line.html
+++ b/inboxen/templates/inboxen/includes/email_line.html
@@ -13,15 +13,15 @@
         <div title="{{ received_date|date:"r" }}" class="email-reveived col-xs-5 col-md-1 col-md-push-8">{{ received_date|naturaltime }}</div>
         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
             <button title="{% trans "Delete" %}" class="close" type="submit" name="delete-single" value="{{ eid }}">
-                <span class="fa fa-times fa-lg" aria-hidden="true"></span><span class="sr-only">{% trans "Delete" %}</span>
+                <span class="fa fa-times fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Delete" %}</span>
             </button>
             <button title="{% trans "Toggle Importantance" %}" class="close" type="submit" name="important-single" value="{{ eid }}">
-                <span class="fa fa-star fa-lg" aria-hidden="true"></span><span class="sr-only">{% trans "Toggle Importantance" %}</span>
+                <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Toggle Importantance" %}</span>
             </button>
             {% if unified %}
-                <a class="close" title="{% trans "Inbox" %}" href="{% url 'single-inbox' inbox=inbox domain=domain %}">
-                    <span class="fa fa-inbox fa-lg" aria-hidden="true"></span><span class="sr-only">{% trans "Inbox" %}</span>
-                </a>
+            <a class="close" title="{% trans "Inbox" %}" href="{% url 'single-inbox' inbox=inbox domain=domain %}">
+                <span class="fa fa-inbox fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Inbox" %}</span>
+            </a>
             {% endif %}
         </div>
     </span>

--- a/inboxen/templates/inboxen/includes/inbox_line.html
+++ b/inboxen/templates/inboxen/includes/inbox_line.html
@@ -17,10 +17,10 @@
                 {# form per line because we can't have forms within forms when inlining edit inbox forms #}
                 {% csrf_token %}
                 <a title="{% trans "Options" %} " class="close" href="{% url 'inbox-edit' inbox=inbox domain=domain %}">
-                    <span class="fa fa-pencil fa-lg" aria-hidden="true"></span><span class="sr-only">{% trans "Inbox Options" %}</span>
+                    <span class="fa fa-pencil fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Inbox Options" %}</span>
                 </a>
                 <button title="{% trans "Pin" %}" type="submit" name="pin-inbox" value="{{ inbox }}@{{ domain }}" class="close">
-                    <span class="fa fa-thumb-tack fa-lg" aria-hidden="true"></span><span class="sr-only">{% trans "Pin Inbox" %}</span>
+                    <span class="fa fa-thumb-tack fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Pin Inbox" %}</span>
                 </button>
             </form>
         </div>

--- a/inboxen/templates/inboxen/styleguide.html
+++ b/inboxen/templates/inboxen/styleguide.html
@@ -172,12 +172,14 @@
                         <div title="2017-01-01" class="email-reveived col-xs-5 col-md-1 col-md-push-8">Tuesday</div>
                         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
                             <button title="Delete" class="close">
-                                <span class="fa fa-times fa-lg" aria-hidden="true"></span><span class="sr-only">Delete</span>
+                                <span class="fa fa-times fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Delete</span>
                             </button>
                             <button title="Toggle Importantance" class="close">
-                                <span class="fa fa-star fa-lg" aria-hidden="true"></span><span class="sr-only">Toggle Importantance</span>
+                                <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Toggle Importantance</span>
                             </button>
-                            <a class="close" title="Inbox"><span class="fa fa-inbox fa-lg" aria-hidden="true"></span><span class="sr-only">Inbox</span></a>
+                            <a class="close" title="Inbox">
+                                <span class="fa fa-inbox fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Inbox</span>
+                            </a>
                         </div>
                     </span>
                     <a class="clickable" href="#">
@@ -200,12 +202,14 @@
                         <div title="2017-01-01" class="email-reveived col-xs-5 col-md-1 col-md-push-8">Tuesday</div>
                         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
                             <button title="Delete" class="close">
-                                <span class="fa fa-times fa-lg" aria-hidden="true"></span><span class="sr-only">Delete</span>
+                                <span class="fa fa-times fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Delete</span>
                             </button>
                             <button title="Toggle Importantance" class="close">
-                                <span class="fa fa-star fa-lg" aria-hidden="true"></span><span class="sr-only">Toggle Importantance</span>
+                                <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Toggle Importantance</span>
                             </button>
-                            <a class="close" title="Inbox"><span class="fa fa-inbox fa-lg" aria-hidden="true"></span><span class="sr-only">Inbox</span></a>
+                            <a class="close" title="Inbox">
+                                <span class="fa fa-inbox fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Inbox</span>
+                            </a>
                         </div>
                     </span>
                     <a class="clickable" href="#">
@@ -258,7 +262,7 @@
                         <div class="inbox-options {{ col3 }}">
                             <form>
                                 <a title="Options" class="close" href="#">
-                                    <span class="fa fa-pencil fa-lg" aria-hidden="true"></span><span class="sr-only">Inbox Options</span>
+                                    <span class="fa fa-pencil fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Inbox Options</span>
                                 </a>
                             </form>
                         </div>
@@ -299,10 +303,10 @@
                         <div class="inbox-options {{ col3 }}">
                             <form>
                                 <a title="Options" class="close" href="#">
-                                    <span class="fa fa-pencil fa-lg" aria-hidden="true"></span><span class="sr-only">Inbox Options</span>
+                                    <span class="fa fa-pencil fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Inbox Options</span>
                                 </a>
                                 <button title="Pin" class="close">
-                                    <span class="fa fa-thumb-tack fa-lg" aria-hidden="true"></span><span class="sr-only">Pin Inbox</span>
+                                    <span class="fa fa-thumb-tack fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">Pin Inbox</span>
                                 </button>
                             </form>
                         </div>

--- a/inboxen/templates/inboxen/user/home.html
+++ b/inboxen/templates/inboxen/user/home.html
@@ -27,10 +27,10 @@
                     <div class="inbox-flags col-xs-12 col-sm-4">{{ user.inboxenprofile.flags|render_flags }}</div>
                 </div>
             </div>
-        </span>
-        <a class="clickable" href="{% url 'unified-inbox' %}">
             <div class="{{ col2 }}">&nbsp;</div>
             <div class="{{ col3 }}">&nbsp;</div>
+        </span>
+        <a class="clickable" href="{% url 'unified-inbox' %}">
             <div class="{{ col4 }}">&nbsp;</div>
         </a>
     </div>


### PR DESCRIPTION
Greatly improves the ability of sighted keyboard users to navigate the home and inbox pages.

On desktop, buttons have reversed order. This was unavoidable to do as it would either happen on desktop or mobile and the order on mobile was the intended order.

Fixes #278 