### PR TITLE
Make Inboxen source compatible with Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Set X-XSS-Protection to something other than its dangerous default (#297)
 * Set HSTS headers in Django - this makes HSTS no longer optional (#298)
 * Test security features (#298)
+* Used Sixer to make source code compatible with Python 3
+  * This is just a first step ot make Inboxen work on Python 3
 
 ## Releases
 

--- a/account/tests/test_passwordfield.py
+++ b/account/tests/test_passwordfield.py
@@ -48,7 +48,7 @@ class PasswordFieldTestCase(InboxenTestCase):
             u'You password should contain at least 2 of the following: letters, numbers, spaces, punctuation.',
         ]
 
-        self.assertItemsEqual(validation_errors, errors)
+        self.assertCountEqual(validation_errors, errors)
 
     def test_field_min(self):
         password = "a !"

--- a/blog/models.py
+++ b/blog/models.py
@@ -21,13 +21,14 @@
 from django.conf import settings
 from django.db import models
 from django.utils import safestring
-
 from django_extensions.db.fields import AutoSlugField
 import markdown
+import six
 
 from inboxen import validators
 
 
+@six.python_2_unicode_compatible
 class BlogPost(models.Model):
     """Basic blog post, body stored as MarkDown"""
     subject = models.CharField(max_length=512, validators=[validators.ProhibitNullCharactersValidator()])
@@ -44,8 +45,8 @@ class BlogPost(models.Model):
         """Render MarkDown to HTML"""
         return safestring.mark_safe(markdown.markdown(self.body))
 
-    def __unicode__(self):
-        draft = ""
+    def __str__(self):
+        draft = u""
         if self.draft:
             draft = u" (draft)"
 

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -21,6 +21,7 @@ from django.core import urlresolvers
 
 import factory
 import factory.fuzzy
+import six
 
 from blog import models, forms
 from inboxen.tests import factories
@@ -71,7 +72,7 @@ class BlogTestCase(InboxenTestCase):
         self.assertEqual(post.subject, SUBJECT)
         self.assertEqual(post.body, BODY)
         self.assertEqual(post.date, None)
-        self.assertEqual(type(post.__unicode__()), unicode)
+        self.assertEqual(type(post.__unicode__()), six.text_type)
 
         url = urlresolvers.reverse('blog-post', kwargs={"slug": post.slug})
 

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -72,7 +72,7 @@ class BlogTestCase(InboxenTestCase):
         self.assertEqual(post.subject, SUBJECT)
         self.assertEqual(post.body, BODY)
         self.assertEqual(post.date, None)
-        self.assertEqual(type(post.__unicode__()), six.text_type)
+        self.assertEqual(six.text_type(post), "{} (draft)".format(post.subject))
 
         url = urlresolvers.reverse('blog-post', kwargs={"slug": post.slug})
 
@@ -85,6 +85,7 @@ class BlogTestCase(InboxenTestCase):
         post = models.BlogPost.objects.get()
         self.assertNotEqual(post.date, None)
         self.assertNotEqual(post.modified, old_mod)
+        self.assertEqual(six.text_type(post), "{}".format(post.subject))
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/cms/fields.py
+++ b/cms/fields.py
@@ -22,6 +22,7 @@ from django.utils import safestring
 from django.utils.functional import cached_property
 from lxml.html.clean import Cleaner
 import markdown
+import six
 
 from cms.widgets import RichTextInput
 
@@ -33,14 +34,14 @@ DEFAULT_MARKDOWN_EXTENSIONS = []
 DEFAULT_MARKDOWN_EXTENSION_CONFIGS = {}
 
 
-class HTML(unicode):
+class HTML(six.text_type):
     # Unicode subclass so that it looks like a normal unicode object to the
     # rest of Django, but still has a nice render method. Avoids having to
     # write masses of conversion methods to make sure the database gets an
     # object type it understands.
     def __new__(cls, text, allow_tags, safe_attrs, extensions=None, extension_configs=None):
         # call unicode directly, because super(HTML, HTML) will look wrong
-        text = unicode.__new__(cls, text)
+        text = six.text_type.__new__(cls, text)
         text.allow_tags = allow_tags
         text.safe_attrs = safe_attrs
         text.extensions = extensions or []

--- a/cms/models.py
+++ b/cms/models.py
@@ -39,7 +39,7 @@ from cms.fields import (
 from inboxen import validators
 
 
-HELP_PAGE_TAGS = DEFAULT_ALLOW_TAGS + ["h%s" % i for i in xrange(1, 6)]
+HELP_PAGE_TAGS = DEFAULT_ALLOW_TAGS + ["h%s" % i for i in range(1, 6)]
 HELP_PAGE_ATTRS = DEFAULT_SAFE_ATTRS + ["id"]
 HELP_PAGE_EXTENSIONS = DEFAULT_MARKDOWN_EXTENSIONS + ["markdown.extensions.toc"]
 HELP_PAGE_EXTENSION_CONFIGS = {"markdown.extensions.toc": {"anchorlink": True}}

--- a/cms/tests/test_models.py
+++ b/cms/tests/test_models.py
@@ -168,7 +168,7 @@ class HelpIndexTestCase(InboxenTestCase):
         request = MockRequest()
 
         ctx = page.get_context(request)
-        self.assertItemsEqual(ctx.keys(), ["page", "menu"])
+        self.assertCountEqual(ctx.keys(), ["page", "menu"])
         self.assertEqual(ctx["page"], page)
         self.assertEqual(list(ctx["menu"]), [models.HelpBasePage.objects.get(parent__pk=page.pk)])
 

--- a/inboxen/models.py
+++ b/inboxen/models.py
@@ -20,16 +20,15 @@
 import os.path
 import re
 
+from annoying.fields import AutoOneToOneField, JSONField
+from bitfield import BitField
 from django.conf import settings
 from django.db import models, transaction
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _
 from django.utils.functional import cached_property
-import six
-
-from annoying.fields import AutoOneToOneField, JSONField
-from bitfield import BitField
+from django.utils.translation import ugettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
+import six
 
 from inboxen.managers import BodyQuerySet, DomainQuerySet, EmailQuerySet, HeaderQuerySet, InboxQuerySet
 from inboxen import validators
@@ -37,6 +36,7 @@ from inboxen import validators
 HEADER_PARAMS = re.compile(r'([a-zA-Z0-9]+)=["\']?([^"\';=]+)["\']?[;]?')
 
 
+@six.python_2_unicode_compatible
 class UserProfile(models.Model):
     """This is auto-created when accessed via a RelatedManager
 
@@ -69,10 +69,11 @@ class UserProfile(models.Model):
 
         return left
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Profile for %s" % self.user
 
 
+@six.python_2_unicode_compatible
 class Statistic(models.Model):
     """Statistics about users"""
     date = models.DateTimeField('date', auto_now_add=True)
@@ -81,10 +82,11 @@ class Statistic(models.Model):
     emails = JSONField()
     inboxes = JSONField()
 
-    def __unicode__(self):
+    def __str__(self):
         return six.text_type(self.date)
 
 
+@six.python_2_unicode_compatible
 class Liberation(models.Model):
     """Liberation data
 
@@ -110,7 +112,7 @@ class Liberation(models.Model):
 
     path = property(get_path, set_path)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Liberation for %s" % self.user
 
 
@@ -119,6 +121,7 @@ class Liberation(models.Model):
 ##
 
 
+@six.python_2_unicode_compatible
 class Domain(models.Model):
     """Domain model
 
@@ -130,10 +133,11 @@ class Domain(models.Model):
 
     objects = DomainQuerySet.as_manager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.domain
 
 
+@six.python_2_unicode_compatible
 class Inbox(models.Model):
     """Inbox model
 
@@ -156,7 +160,7 @@ class Inbox(models.Model):
 
     objects = InboxQuerySet.as_manager()
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s@%s" % (self.inbox, self.domain.domain)
 
     def __repr__(self):
@@ -170,6 +174,7 @@ class Inbox(models.Model):
         unique_together = (('inbox', 'domain'),)
 
 
+@six.python_2_unicode_compatible
 class Request(models.Model):
     """Inbox allocation request model"""
     amount = models.IntegerField(help_text=_("Pool increase requested"))
@@ -187,7 +192,7 @@ class Request(models.Model):
             self.requester.inboxenprofile.save()
         super(Request, self).save(*args, **kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Request for %s (%s)" % (self.requester, self.succeeded)
 
 ##
@@ -195,6 +200,7 @@ class Request(models.Model):
 ##
 
 
+@six.python_2_unicode_compatible
 class Email(models.Model):
     """Email model
 
@@ -214,7 +220,7 @@ class Email(models.Model):
         """Return a hexidecimal version of ID"""
         return hex(self.id)[2:].rstrip("L")
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{0}".format(self.eid)
 
     def get_parts(self):
@@ -233,6 +239,7 @@ class Email(models.Model):
             return None
 
 
+@six.python_2_unicode_compatible
 class Body(models.Model):
     """Body model
 
@@ -252,10 +259,11 @@ class Body(models.Model):
             self.size = len(self.data)
         return super(Body, self).save(*args, **kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.hashed
 
 
+@six.python_2_unicode_compatible
 class PartList(MPTTModel):
     """Part model
 
@@ -269,7 +277,7 @@ class PartList(MPTTModel):
     body = models.ForeignKey(Body, on_delete=models.PROTECT)
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children')
 
-    def __unicode__(self):
+    def __str__(self):
         return six.text_type(self.id)
 
     @cached_property
@@ -317,6 +325,7 @@ class PartList(MPTTModel):
         return self._content_headers_cache.get("charset")
 
 
+@six.python_2_unicode_compatible
 class HeaderName(models.Model):
     """Header name model
 
@@ -324,10 +333,11 @@ class HeaderName(models.Model):
     """
     name = models.CharField(max_length=78, unique=True, validators=[validators.ProhibitNullCharactersValidator()])
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@six.python_2_unicode_compatible
 class HeaderData(models.Model):
     """Header data model
 
@@ -336,10 +346,11 @@ class HeaderData(models.Model):
     hashed = models.CharField(max_length=80, unique=True, validators=[validators.ProhibitNullCharactersValidator()])  # <algo>:<hash>
     data = models.TextField(validators=[validators.ProhibitNullCharactersValidator()])
 
-    def __unicode__(self):
+    def __str__(self):
         return self.hashed
 
 
+@six.python_2_unicode_compatible
 class Header(models.Model):
     """Header model
 
@@ -355,5 +366,5 @@ class Header(models.Model):
 
     objects = HeaderQuerySet.as_manager()
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{0}".format(self.name.name)

--- a/inboxen/models.py
+++ b/inboxen/models.py
@@ -25,6 +25,7 @@ from django.db import models, transaction
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext_lazy as _
 from django.utils.functional import cached_property
+import six
 
 from annoying.fields import AutoOneToOneField, JSONField
 from bitfield import BitField
@@ -81,7 +82,7 @@ class Statistic(models.Model):
     inboxes = JSONField()
 
     def __unicode__(self):
-        return unicode(self.date)
+        return six.text_type(self.date)
 
 
 class Liberation(models.Model):
@@ -159,7 +160,7 @@ class Inbox(models.Model):
         return u"%s@%s" % (self.inbox, self.domain.domain)
 
     def __repr__(self):
-        u_rep = unicode(self)
+        u_rep = six.text_type(self)
         if self.flags.deleted:
             u_rep = "%s (deleted)" % u_rep
         return smart_str(u'<%s: %s>' % (self.__class__.__name__, u_rep), errors="replace")
@@ -238,7 +239,7 @@ class Body(models.Model):
     Object manager has a get_or_create() method that deals with duplicated
     bodies.
 
-    This model expects and returns binary data, converting to and from unicode happens elsewhere
+    This model expects and returns binary data, converting to and from six.text_type happens elsewhere
     """
     hashed = models.CharField(max_length=80, unique=True, validators=[validators.ProhibitNullCharactersValidator()])  # <algo>:<hash>
     data = models.BinaryField(default="")
@@ -269,7 +270,7 @@ class PartList(MPTTModel):
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children')
 
     def __unicode__(self):
-        return unicode(self.id)
+        return six.text_type(self.id)
 
     @cached_property
     def _content_headers_cache(self):

--- a/inboxen/search.py
+++ b/inboxen/search.py
@@ -21,6 +21,7 @@ from django.core import exceptions
 from django.db.models import Q
 
 from watson import search
+import six
 
 from inboxen.utils.email import unicode_damnit, find_bodies
 
@@ -62,7 +63,7 @@ class EmailSearchAdapter(search.SearchAdapter):
         """Fetch first text/plain body for obj, reading up to `trunc_to_size`
         bytes
         """
-        bodies = find_bodies(obj.get_parts()).next()
+        bodies = six.next(find_bodies(obj.get_parts()))
 
         if bodies is not None:
             return choose_body(bodies)[:self.trunc_to_size]

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -269,11 +269,12 @@ SALMON_SERVER = {"host": "localhost", "port": 8823, "type": "smtp"}
 try:
     process = Popen("git rev-parse HEAD".split(), stdout=PIPE, close_fds=True, cwd=BASE_DIR)
     output = process.communicate()[0].strip()
+    output = output.decode()
     if not process.returncode:
         os.environ["INBOXEN_COMMIT_ID"] = output
     else:
         os.environ["INBOXEN_COMMIT_ID"] = "UNKNOWN"
-except OSError, TypeError:
+except (OSError, TypeError):
     os.environ["INBOXEN_COMMIT_ID"] = "UNKNOWN"
 
 EMAIL_SUBJECT_PREFIX = "[{}] ".format(SITE_NAME)  # trailing space is important

--- a/inboxen/tasks.py
+++ b/inboxen/tasks.py
@@ -21,7 +21,6 @@ from datetime import datetime, timedelta
 from importlib import import_module
 import gc
 import logging
-import urllib
 
 from django.apps import apps
 from django.conf import settings
@@ -31,6 +30,7 @@ from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.db.models import Avg, Case, Count, F, Max, Min, StdDev, Sum, When, IntegerField
 from django.db.models.functions import Coalesce
+from six.moves import urllib
 
 from pytz import utc
 from watson import search as watson_search
@@ -219,7 +219,7 @@ def search(user_id, search_term):
     }
 
     key = u"{0}-{1}".format(user_id, search_term)
-    key = urllib.quote(key.encode("utf-8"))
+    key = urllib.parse.quote(key.encode("utf-8"))
 
     cache.set(key, results, SEARCH_TIMEOUT)
 

--- a/inboxen/test.py
+++ b/inboxen/test.py
@@ -35,6 +35,7 @@ from djcelery.contrib.test_runner import CeleryTestSuiteRunner
 from sudo import settings as sudo_settings
 from sudo.middleware import SudoMiddleware
 from sudo.utils import get_random_string
+import six
 
 
 _log = logging.getLogger(__name__)
@@ -181,3 +182,9 @@ class SecureClient(test.Client):
 
 class InboxenTestCase(test.TestCase):
     client_class = SecureClient
+
+    def assertCountEqual(self, actual, expected, msg=None):
+        if six.PY3:
+            return super(InboxenTestCase, self).assertCountEqual(actual, expected, msg)
+        else:
+            return self.assertItemsEqual(actual, expected, msg)

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -22,6 +22,7 @@ from django import test
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core import urlresolvers
 from salmon import mail
+import six
 
 import mock
 
@@ -436,7 +437,7 @@ class AttachmentTestCase(InboxenTestCase):
 class UtilityTestCase(InboxenTestCase):
     def test_is_unicode(self):
         string = "Hey there!"
-        self.assertTrue(isinstance(email_utils.unicode_damnit(string), unicode))
+        self.assertTrue(isinstance(email_utils.unicode_damnit(string), six.text_type))
 
     def test_unicode_passthrough(self):
         already_unicode = u"€"
@@ -454,14 +455,14 @@ class UtilityTestCase(InboxenTestCase):
     def test_clean_html_no_charset(self):
         email = {"display_images": True}
         returned_body = email_utils._clean_html_body(None, email, CHARSETLESS_BODY, "ascii")
-        self.assertIsInstance(returned_body, unicode)
+        self.assertIsInstance(returned_body, six.text_type)
 
     def test_clean_html_unsupported_css(self):
         email = {"display_images": True, "eid": "abc"}
         with mock.patch("inboxen.utils.email.messages") as msg_mock:
             returned_body = email_utils._clean_html_body(None, email, UNSUPPORTED_CSS_BODY, "ascii")
             self.assertEqual(msg_mock.info.call_count, 1)
-        self.assertIsInstance(returned_body, unicode)
+        self.assertIsInstance(returned_body, six.text_type)
 
     def test_clean_html_balance_tags_when_closing_tag_missing(self):
         email = {"display_images": True, "eid": "abc"}
@@ -489,7 +490,7 @@ class UtilityTestCase(InboxenTestCase):
         with mock.patch("inboxen.utils.email.messages") as msg_mock:
             returned_body = email_utils.render_body(None, email, [part])
             self.assertEqual(msg_mock.error.call_count, 1)
-        self.assertIsInstance(returned_body, unicode)
+        self.assertIsInstance(returned_body, six.text_type)
 
     def test_render_body_bad_http_equiv(self):
         email = {"display_images": True, "eid": "abc"}
@@ -499,12 +500,12 @@ class UtilityTestCase(InboxenTestCase):
         part.body.data = BAD_HTTP_EQUIV_BODY
 
         returned_body = email_utils.render_body(None, email, [part])
-        self.assertIsInstance(returned_body, unicode)
+        self.assertIsInstance(returned_body, six.text_type)
 
     def test_invalid_charset(self):
         text = "Växjö"
         self.assertEqual(email_utils.unicode_damnit(text, "utf-8"), u"Växjö")
-        self.assertEqual(email_utils.unicode_damnit(text, "unicode"), u"V\ufffd\ufffdxj\ufffd\ufffd")
+        self.assertEqual(email_utils.unicode_damnit(text, "six.text_type"), u"V\ufffd\ufffdxj\ufffd\ufffd")
 
     def test_find_bodies_with_bad_mime_tree(self):
         email = factories.EmailFactory()

--- a/inboxen/tests/test_misc.py
+++ b/inboxen/tests/test_misc.py
@@ -17,7 +17,6 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from StringIO import StringIO
 from email.message import Message
 from subprocess import CalledProcessError
 import sys
@@ -31,6 +30,8 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied, Valid
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.client import RequestFactory
+from six import StringIO
+from six.moves import reload_module
 
 import mock
 
@@ -50,7 +51,7 @@ def reload_urlconf():
     Make sure to use clear_url_caches along with this
     """
     if dj_settings.ROOT_URLCONF in sys.modules:
-        conf = reload(sys.modules[dj_settings.ROOT_URLCONF])
+        conf = reload_module(sys.modules[dj_settings.ROOT_URLCONF])
     else:
         from inboxen import urls as conf
 

--- a/inboxen/tests/test_models.py
+++ b/inboxen/tests/test_models.py
@@ -251,7 +251,8 @@ class ModelTestCase(InboxenTestCase):
         profile.available_inboxes()
         self.assertEqual(models.Request.objects.count(), 1)
 
-        self.assertEqual(type(models.Request.objects.get().__unicode__()), six.text_type)
+        request = models.Request.objects.get()
+        self.assertEqual(six.text_type(request), "Request for {} ({})".format(request.requester, request.succeeded))
 
 
 class ModelFlagsTestCase(InboxenTestCase):

--- a/inboxen/tests/test_models.py
+++ b/inboxen/tests/test_models.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from pytz import utc
 import mock
+import six
 
 from inboxen import models
 from inboxen.tests import factories
@@ -250,7 +251,7 @@ class ModelTestCase(InboxenTestCase):
         profile.available_inboxes()
         self.assertEqual(models.Request.objects.count(), 1)
 
-        self.assertEqual(type(models.Request.objects.get().__unicode__()), unicode)
+        self.assertEqual(type(models.Request.objects.get().__unicode__()), six.text_type)
 
 
 class ModelFlagsTestCase(InboxenTestCase):

--- a/inboxen/tests/test_search.py
+++ b/inboxen/tests/test_search.py
@@ -19,9 +19,9 @@
 ##
 
 import mock
-import urllib
 
 from django.core import urlresolvers, cache
+from six.moves import urllib
 
 from inboxen.tests import factories
 from inboxen.test import MockRequest, InboxenTestCase
@@ -36,7 +36,7 @@ class SearchViewTestCase(InboxenTestCase):
 
         self.url = urlresolvers.reverse("user-search", kwargs={"q": "cheddär"})
         key = "%s-cheddär" % self.user.id
-        self.key = urllib.quote(key)
+        self.key = urllib.parse.quote(key)
 
         if not login:
             raise Exception("Could not log in")

--- a/inboxen/tests/test_search.py
+++ b/inboxen/tests/test_search.py
@@ -45,7 +45,7 @@ class SearchViewTestCase(InboxenTestCase):
         cache.cache.set(self.key, {"emails": [], "inboxes": []})
         response = self.client.get(self.url)
         self.assertIn("search_results", response.context)
-        self.assertItemsEqual(response.context["search_results"], ["emails", "inboxes"])
+        self.assertCountEqual(response.context["search_results"], ["emails", "inboxes"])
 
     def test_content(self):
         cache.cache.set(self.key, {"emails": [], "inboxes": []})

--- a/inboxen/tests/test_stats.py
+++ b/inboxen/tests/test_stats.py
@@ -47,7 +47,7 @@ class StatsViewTestCase(InboxenTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/json")
         data = json.loads(response.content)
-        self.assertItemsEqual(["dates", "users", "inboxes", "emails", "now", "read_emails", "active_users", "active_inboxes"], data.keys())
+        self.assertCountEqual(["dates", "users", "inboxes", "emails", "now", "read_emails", "active_users", "active_inboxes"], data.keys())
 
     def test_recent_missing_points(self):
         def format_date(date):
@@ -69,7 +69,7 @@ class StatsViewTestCase(InboxenTestCase):
         # remove "now" - it will be current time
         del data["now"]
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             data.items(),
             (
                 ("dates", [format_date(stat1.date), format_date(stat2.date)]),

--- a/inboxen/tests/test_tasks.py
+++ b/inboxen/tests/test_tasks.py
@@ -162,7 +162,7 @@ class SearchTestCase(InboxenTestCase):
     def test_search(self):
         user = factories.UserFactory()
         result = tasks.search.delay(user.id, "bizz").get()
-        self.assertItemsEqual(result.keys(), ["emails", "inboxes"])
+        self.assertCountEqual(result.keys(), ["emails", "inboxes"])
 
 
 @override_settings(

--- a/inboxen/utils/__init__.py
+++ b/inboxen/utils/__init__.py
@@ -50,7 +50,7 @@ def generate_maintenance_page():
     rendered = template.render(context)
 
     try:
-        os.mkdir(output_dir, 0711)
+        os.mkdir(output_dir, 0o711)
     except OSError:
         pass
 

--- a/inboxen/utils/email.py
+++ b/inboxen/utils/email.py
@@ -21,6 +21,8 @@ models.py) for emails
 
 It's in "utils" because "domain.py" would get confusing :P """
 
+from __future__ import print_function
+
 import re
 import logging
 
@@ -28,6 +30,7 @@ from django.contrib import messages
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import html as html_utils, safestring
 from django.utils.translation import ugettext as _
+import six
 
 from lxml import etree, html as lxml_html
 from lxml.html.clean import Cleaner
@@ -56,15 +59,15 @@ class InboxenPremailer(Premailer):
 
 def unicode_damnit(data, charset="utf-8", errors="replace"):
     """Makes doubley sure that we can turn the database's binary typees into
-    unicode objects
+    six.text_type objects
     """
-    if isinstance(data, unicode):
+    if isinstance(data, six.text_type):
         return data
 
     try:
-        return unicode(str(data), charset, errors)
+        return six.text_type(six.binary_type(data), charset, errors)
     except LookupError:
-        return unicode(str(data), "ascii", errors)
+        return six.text_type(six.binary_type(data), "ascii", errors)
 
 
 def _clean_html_body(request, email, body, charset):
@@ -225,7 +228,7 @@ def find_bodies(part):
     Generator that returns lists of sibling parts. Sibling parts should not be
     displayed together, but are alternatives to eachother, e.g.:
 
-        >>> print [i for i in find_bodies(root_part)]
+        >>> print([i for i in find_bodies(root_part)])
         [[part1], [html_part2, plain_part2], [part3]]
 
     Where part1 and part2 might be children of "multipart/mixed" (and they're
@@ -291,7 +294,7 @@ def print_tree(part, func=lambda x: str(x)):
     argument and returns a string
     """
     indent = "\t" * part.get_level()
-    print "{}{}".format(indent, func(part))
+    print("{}{}".format(indent, func(part)))
 
     for child in part.get_children():
         print_tree(child, func)

--- a/inboxen/views/__init__.py
+++ b/inboxen/views/__init__.py
@@ -20,4 +20,4 @@ from .index import *
 from .stats import *
 from .styleguide import styleguide
 from .user import *
-import error
+from . import error

--- a/inboxen/views/user/search.py
+++ b/inboxen/views/user/search.py
@@ -17,13 +17,13 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-import urllib
 
 from django import http
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.translation import ugettext as _
 from django.views import generic
+from six.moves import urllib
 
 from braces.views import LoginRequiredMixin
 
@@ -53,7 +53,7 @@ class SearchView(LoginRequiredMixin, generic.ListView):
 
     def get_cache_key(self):
         key = u"{0}-{1}".format(self.request.user.id, self.query)
-        return urllib.quote(key.encode("utf-8"))
+        return urllib.parse.quote(key.encode("utf-8"))
 
     def get_results(self):
         """Fetch result from either the cache or the queue

--- a/liberation/tests.py
+++ b/liberation/tests.py
@@ -18,7 +18,6 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from StringIO import StringIO
 from importlib import import_module
 import base64
 import itertools
@@ -36,6 +35,7 @@ from django.contrib.auth import get_user_model
 from django.core import urlresolvers
 from django.core.urlresolvers import reverse
 from salmon import mail
+from six import StringIO
 
 from inboxen import models
 from inboxen.tests.example_emails import (

--- a/liberation/tests.py
+++ b/liberation/tests.py
@@ -94,7 +94,7 @@ class LiberateTestCase(InboxenTestCase):
         self.assertTrue(os.path.exists(os.path.join(self.mail_dir, '.' + result["folder"])))
 
         email_ids = models.Email.objects.filter(inbox=self.inboxes[0]).values_list("id", flat=True)
-        self.assertItemsEqual(email_ids, result["ids"])
+        self.assertCountEqual(email_ids, result["ids"])
 
     def test_liberate_message(self):
         inbox = tasks.liberate_inbox(self.mail_dir, self.inboxes[0].id)["folder"]

--- a/liberation/utils.py
+++ b/liberation/utils.py
@@ -17,12 +17,13 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from StringIO import StringIO
 from email.header import Header
 from email.message import Message
 import base64
 import quopri
 import uu
+
+from six import StringIO
 
 from inboxen.models import HEADER_PARAMS
 

--- a/router/app/helpers.py
+++ b/router/app/helpers.py
@@ -24,6 +24,7 @@ import logging
 
 from pytz import utc
 from watson import search
+import six
 
 from inboxen.models import Body, Email, Header, PartList
 
@@ -67,7 +68,7 @@ def make_email(message, inbox):
 
 def encode_body(part):
     """Make certain that the body of a part is bytes and not unicode"""
-    if isinstance(part.body, unicode):
+    if isinstance(part.body, six.text_type):
         ctype, params = part.content_encoding['Content-Type']
         try:
             data = part.body.encode(params.get("charset", "ascii"))

--- a/router/app/server.py
+++ b/router/app/server.py
@@ -76,7 +76,7 @@ def process_message(message, inbox=None, domain=None):
             profile.flags.unified_has_new_messages = True
             profile.save(update_fields=["flags"])
 
-    except DatabaseError, e:
+    except DatabaseError as e:
         log.exception("DB error: %s", e)
         raise SMTPError(451, "Error processing message, try again later.")
     except Inbox.DoesNotExist:

--- a/router/config/boot.py
+++ b/router/config/boot.py
@@ -30,12 +30,12 @@ from config import settings
 __all__ = ["settings"]
 
 try:
-    os.mkdir("logs", 0700)
+    os.mkdir("logs", 0o700)
 except OSError:
     pass
 
 try:
-    os.mkdir("run", 0710)  # group can access files in "run"
+    os.mkdir("run", 0o710)  # group can access files in "run"
 except OSError:
     pass
 

--- a/tickets/models.py
+++ b/tickets/models.py
@@ -21,9 +21,9 @@ from django.conf import settings
 from django.db import models
 from django.utils import safestring
 from django.utils.translation import ugettext_lazy as _
-
 from lxml.html.clean import Cleaner
 import markdown
+import six
 
 from inboxen import validators
 from tickets import managers
@@ -45,6 +45,7 @@ class RenderBodyMixin(object):
         return safestring.mark_safe(body)
 
 
+@six.python_2_unicode_compatible
 class Question(models.Model, RenderBodyMixin):
     # status contants
     NEW = 0
@@ -83,13 +84,14 @@ class Question(models.Model, RenderBodyMixin):
         else:
             return self.last_modified
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s from %s" % (self.subject, self.author)
 
     class Meta:
         ordering = ["-date"]
 
 
+@six.python_2_unicode_compatible
 class Response(models.Model, RenderBodyMixin):
     question = models.ForeignKey(Question)
     author = models.ForeignKey(settings.AUTH_USER_MODEL)
@@ -100,5 +102,5 @@ class Response(models.Model, RenderBodyMixin):
     class Meta:
         ordering = ["date"]
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Response to %s from %s" %(self.question, self.author)

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -265,10 +265,10 @@ class QuestionModelTestCase(InboxenTestCase):
 
     def test_unicode(self):
         question = QuestionFactory(author=self.user)
-        self.assertEqual(type(question.__unicode__()), six.text_type)
+        self.assertEqual(six.text_type(question), "{} from {}".format(question.subject, question.author))
 
         response = ResponseFactory(question=question, author=self.user)
-        self.assertEqual(type(response.__unicode__()), six.text_type)
+        self.assertEqual(six.text_type(response), "Response to {} from {} from {}".format(question.subject, question.author, response.author))
 
 
 class RenderBodyTestCase(InboxenTestCase):

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -18,6 +18,7 @@
 ##
 
 import mock
+import six
 
 from django import test
 from django.core import mail, urlresolvers
@@ -264,10 +265,10 @@ class QuestionModelTestCase(InboxenTestCase):
 
     def test_unicode(self):
         question = QuestionFactory(author=self.user)
-        self.assertEqual(type(question.__unicode__()), unicode)
+        self.assertEqual(type(question.__unicode__()), six.text_type)
 
         response = ResponseFactory(question=question, author=self.user)
-        self.assertEqual(type(response.__unicode__()), unicode)
+        self.assertEqual(type(response.__unicode__()), six.text_type)
 
 
 class RenderBodyTestCase(InboxenTestCase):
@@ -302,7 +303,7 @@ class RenderBodyTestCase(InboxenTestCase):
 class RenderStatus(InboxenTestCase):
     def test_render(self):
         result = tickets_flags.render_status(models.Question.NEW)
-        self.assertIn(unicode(tickets_flags.STATUSES[models.Question.NEW]), result)
-        self.assertIn(unicode(tickets_flags.STATUS_TO_TAGS[models.Question.NEW]["class"]), result)
+        self.assertIn(six.text_type(tickets_flags.STATUSES[models.Question.NEW]), result)
+        self.assertIn(six.text_type(tickets_flags.STATUS_TO_TAGS[models.Question.NEW]["class"]), result)
 
         self.assertNotEqual(tickets_flags.render_status(models.Question.RESOLVED), result)


### PR DESCRIPTION
This is the first step in making Inboxen Python 3 compatible. Tests still fail under Python 3, but there are no syntax errors.

See #261 