### PR TITLE
Make error pages nicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Used Sixer to make source code compatible with Python 3
   * This is just a first step ot make Inboxen work on Python 3
 * Use labels on admin lists for better readability (#263)
+* Change text on error pages to be slightly more verbose (#302)
 
 ## Releases
 

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -247,7 +247,7 @@ CSP_STYLE_SRC = ("'self'",)
 
 CSRF_COOKIE_SECURE = True
 CSRF_USE_SESSIONS = True
-CSRF_FAILURE_VIEW = "inboxen.views.error.permission_denied"
+CSRF_FAILURE_VIEW = "inboxen.views.error.csrf_failure"
 
 SUDO_URL = urlresolvers.reverse_lazy("user-sudo")
 

--- a/inboxen/templates/inboxen/error.html
+++ b/inboxen/templates/inboxen/error.html
@@ -4,6 +4,6 @@
 {% block headline %}{{ headline }}{% endblock %}
 
 {% block content %}
-    <h2>{{ headline }}</h2>
-    <p class="alert alert-{{ error_css_class }}"> {{ error_message }} </p>
+    <h2>{{ headline }} <small>{{ error_code }}</small></h2>
+    <p>{{ error_message }}</p>
 {% endblock %}

--- a/inboxen/tests/test_misc.py
+++ b/inboxen/tests/test_misc.py
@@ -411,7 +411,6 @@ class ErrorViewTestCase(InboxenTestCase):
     def test_view(self):
         view_func = ErrorView.as_view(
             error_message="some message or other",
-            error_css_class="some-css-class",
             error_code=499,
             headline="some headline"
         )
@@ -422,7 +421,6 @@ class ErrorViewTestCase(InboxenTestCase):
         self.assertEqual(response.status_code, 499)
         self.assertIn("some message or other", response.content)
         self.assertIn("some headline", response.content)
-        self.assertIn("some-css-class", response.content)
 
     def test_misconfigured(self):
         view_obj = ErrorView()

--- a/inboxen/views/error.py
+++ b/inboxen/views/error.py
@@ -70,35 +70,42 @@ class ErrorView(TemplateView):
 
 
 not_found = ErrorView.as_view(
-    error_message=_("The page you requested cannot be found."),
+    error_message=_("The page you requested does not exist, or it does exist "
+        "but we don't want to show it to you."),
     error_code=404,
     headline=_("Not Found"),
 )
 
 
 permission_denied = ErrorView.as_view(
-    error_message=_("You do not have permission to view this page."),
+    error_message=_("You do not have permission to view this page and you "
+        "probably know that."),
     error_code=403,
     headline=_("Permission Denied"),
 )
 
 
 csrf_failure = ErrorView.as_view(
-    error_message=_("Oh no! Your browser isn't submitting forms correctly."),
+    error_message=_("Oh no! Your browser is either not sending us the correct "
+        "referer header (no, that's not a spelling mistake) or has removed the "
+        "hidden token from the form you just tried to submit."),
     error_code=403,
     headline=_("Permission Denied"),
 )
 
 
 server_error = ErrorView.as_view(
-    error_message=_("There has been an error with our software. Our administrators have been notified."),
+    error_message=_("There has been an error with our software and our "
+        "administrators have been notified. Check the Help pages for how to "
+        "contact the administrators."),
     error_code=500,
     headline=_("Error"),
 )
 
 
 bad_request = ErrorView.as_view(
-    error_message=_("I have no idea what you were trying to do, but you probably shouldn't be doing it!"),
+    error_message=_("I have no idea what you were trying to do, but you "
+        "probably shouldn't be doing it!"),
     error_code=400,
     headline=_("Bad Request"),
 )

--- a/inboxen/views/error.py
+++ b/inboxen/views/error.py
@@ -32,7 +32,6 @@ _log = logging.getLogger(__name__)
 
 class ErrorView(TemplateView):
     error_message = None
-    error_css_class = "warning"
     error_code = None
 
     headline = _("Some sort of error or something")
@@ -46,7 +45,6 @@ class ErrorView(TemplateView):
 
     def get_context_data(self, **kwargs):
         kwargs["error_message"] = self.get_error_message()
-        kwargs["error_css_class"] = self.get_error_css_class()
         kwargs["error_code"] = self.get_error_code()
         kwargs["headline"] = self.headline
         return super(ErrorView, self).get_context_data(**kwargs)
@@ -57,10 +55,6 @@ class ErrorView(TemplateView):
             raise ImproperlyConfigured("Set 'error_message' or override 'get_error_message'")
         else:
             return self.error_message
-
-    def get_error_css_class(self):
-        """Returns a CSS class to be used whatever template is being used"""
-        return self.error_css_class
 
     def get_error_code(self):
         """Returns the numeric HTTP status code"""
@@ -77,7 +71,6 @@ class ErrorView(TemplateView):
 
 not_found = ErrorView.as_view(
     error_message=_("The page you requested cannot be found."),
-    error_css_class="info",
     error_code=404,
     headline=_("Not Found"),
 )
@@ -85,7 +78,6 @@ not_found = ErrorView.as_view(
 
 permission_denied = ErrorView.as_view(
     error_message=_("You do not have permission to view this page."),
-    error_css_class="warning",
     error_code=403,
     headline=_("Permission Denied"),
 )
@@ -93,7 +85,6 @@ permission_denied = ErrorView.as_view(
 
 server_error = ErrorView.as_view(
     error_message=_("There has been an error with our software. Our administrators have been notified."),
-    error_css_class="danger",
     error_code=500,
     headline=_("Error"),
 )
@@ -101,9 +92,8 @@ server_error = ErrorView.as_view(
 
 bad_request = ErrorView.as_view(
     error_message=_("I have no idea what you were trying to do, but you probably shouldn't be doing it!"),
-    error_css_class="info",
     error_code=400,
-    headline=_("No Idea"),
+    headline=_("Bad Request"),
 )
 
 

--- a/inboxen/views/error.py
+++ b/inboxen/views/error.py
@@ -83,6 +83,13 @@ permission_denied = ErrorView.as_view(
 )
 
 
+csrf_failure = ErrorView.as_view(
+    error_message=_("Oh no! Your browser isn't submitting forms correctly."),
+    error_code=403,
+    headline=_("Permission Denied"),
+)
+
+
 server_error = ErrorView.as_view(
     error_message=_("There has been an error with our software. Our administrators have been notified."),
     error_code=500,


### PR DESCRIPTION
* Removed alert CSS, it made things too hard to read IMO
* Made CSRF failure a separate view with a message relating to CSRF issues
* Display the HTTP code too, mainly because I think it looks cool