### PR TITLE
Use timezone.now and datetime.utcfromtimestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Change text on error pages to be slightly more verbose (#302)
 * Change referrer policy on email view to same-origin (#307)
 * Use a more secure method to produce the random part of inboxes (#312)
+* Cleaned up our use of datetime to make sure we're always using timezone away
+  datetime objects
 
 ## Releases
 

--- a/account/tasks.py
+++ b/account/tasks.py
@@ -21,10 +21,9 @@ import logging
 from datetime import datetime
 
 from celery import chord
-from pytz import utc
-
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from pytz import utc
 
 from inboxen.celery import app
 from inboxen.models import Inbox
@@ -44,11 +43,11 @@ def disown_inbox(inbox_id):
     # delete emails in another task(s)
     batch_delete_items.delay("email", kwargs={'inbox__id': inbox.pk})
 
-    # okay now mark the inbox as deleted
-    inbox.created = datetime.fromtimestamp(0, utc)
+    # remove identifying data from inbox
     inbox.flags.deleted = True
     inbox.description = ""
     inbox.user = None
+    inbox.created = datetime.utcfromtimestamp(0).replace(tzinfo=utc)
     inbox.save()
 
     return True

--- a/account/tests/test_tasks.py
+++ b/account/tests/test_tasks.py
@@ -49,7 +49,7 @@ class DeleteTestCase(InboxenTestCase):
         self.assertTrue(result)
 
         new_inbox = models.Inbox.objects.get(id=inbox.id)
-        self.assertEqual(new_inbox.created, datetime.fromtimestamp(0, utc))
+        self.assertEqual(new_inbox.created, datetime.utcfromtimestamp(0).replace(tzinfo=utc))
         self.assertNotEqual(new_inbox.description, inbox.description)
         self.assertTrue(new_inbox.flags.deleted)
         self.assertEqual(new_inbox.user, None)

--- a/blog/signals.py
+++ b/blog/signals.py
@@ -17,11 +17,9 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from datetime import datetime
-
-from pytz import utc
+from django.utils import timezone
 
 
 def published_checker(sender, instance=None, **kwargs):
     if not instance.draft and instance.date is None:
-        instance.date = datetime.now(utc)
+        instance.date = timezone.now()

--- a/inboxen/managers.py
+++ b/inboxen/managers.py
@@ -18,7 +18,6 @@
 ##
 
 from collections import OrderedDict
-from datetime import datetime
 import hashlib
 
 from django.conf import settings
@@ -26,11 +25,10 @@ from django.db import IntegrityError, models, transaction
 from django.db.models import Q, Max
 from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
+from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.encoding import smart_bytes
 from django.utils.translation import ugettext as _
-
-from pytz import utc
 
 from inboxen.utils import is_reserved
 
@@ -80,7 +78,7 @@ class InboxQuerySet(QuerySet):
                 with transaction.atomic():
                     return super(InboxQuerySet, self).create(
                         inbox=inbox,
-                        created=datetime.now(utc),
+                        created=timezone.now(),
                         domain=domain,
                         **kwargs
                     )

--- a/inboxen/tasks.py
+++ b/inboxen/tasks.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from importlib import import_module
 import gc
 import logging
@@ -30,9 +30,9 @@ from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.db.models import Avg, Case, Count, F, Max, Min, StdDev, Sum, When, IntegerField
 from django.db.models.functions import Coalesce
+from django.utils import timezone
 from six.moves import urllib
 
-from pytz import utc
 from watson import search as watson_search
 
 from inboxen import models
@@ -54,7 +54,7 @@ def statistics():
 
     # the keys of these dictionaries have awful names for historical reasons
     # don't change them unless you want to do a data migration
-    one_day_ago = datetime.now(utc) - timedelta(days=1)
+    one_day_ago = timezone.now() - timedelta(days=1)
     user_aggregate = {
         "count": Count("id", distinct=True),
         "new": Coalesce(Count(

--- a/inboxen/tests/test_models.py
+++ b/inboxen/tests/test_models.py
@@ -22,7 +22,7 @@ import itertools
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from pytz import utc
+from django.utils import timezone
 import mock
 import six
 
@@ -181,7 +181,7 @@ class ModelTestCase(InboxenTestCase):
         self.assertEqual(count, 4)
 
     def test_add_last_activity(self):
-        now = datetime.datetime.now(utc)
+        now = timezone.now()
 
         email = factories.EmailFactory(received_date=now)
         email.inbox.created = now - datetime.timedelta(2)
@@ -355,7 +355,7 @@ class ModelReprTestCase(InboxenTestCase):
         self.assertEqual(repr(request), "<Request: Request for example (False)>")
 
     def test_statistic(self):
-        now = datetime.datetime.now()
+        now = timezone.now()
         stat = models.Statistic(date=now)
         self.assertEqual(repr(stat), "<Statistic: %s>" % now)
 

--- a/inboxen/tests/test_tasks.py
+++ b/inboxen/tests/test_tasks.py
@@ -17,12 +17,11 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.core import mail
 from django.contrib.sessions.models import Session
-
-from pytz import utc
+from django.utils import timezone
 import mock
 
 from inboxen import models, tasks
@@ -126,7 +125,7 @@ class CleanSessionsTestCase(InboxenTestCase):
         Session.objects.create(
             session_key="1234",
             session_data="{}",
-            expire_date=datetime.now() - timedelta(1),
+            expire_date=timezone.now() - timedelta(1),
         )
         self.assertEqual(Session.objects.count(), 1)
         tasks.clean_expired_session.delay()
@@ -174,7 +173,7 @@ class RequestReportTestCase(InboxenTestCase):
         self.user = factories.UserFactory()
         self.user.inboxenprofile  # autocreate a profile
 
-        now = datetime.now(utc)
+        now = timezone.now()
 
         models.Request.objects.create(amount=200, date=now, succeeded=True, requester=self.user, authorizer=self.user)
         self.waiting = models.Request.objects.create(amount=200, date=now, requester=self.user)

--- a/liberation/forms.py
+++ b/liberation/forms.py
@@ -17,12 +17,9 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from datetime import datetime
-
 from django import forms
+from django.utils import timezone
 from django.utils.translation import ugettext as _
-
-from pytz import utc
 
 from inboxen import models
 from liberation.tasks import liberate as data_liberate
@@ -62,7 +59,7 @@ class LiberationForm(forms.ModelForm):
         lib_status = self.user.liberation
         if not lib_status.flags.running:
             lib_status.flags = models.Liberation.flags.running
-            lib_status.started = datetime.now(utc)
+            lib_status.started = timezone.now()
 
             result = data_liberate.apply_async(
                 kwargs={"user_id": self.user.id, "options": self.cleaned_data},

--- a/liberation/tasks.py
+++ b/liberation/tasks.py
@@ -25,7 +25,6 @@ import os
 import string
 import tarfile
 import time
-from datetime import datetime
 from shutil import rmtree
 
 from async_messages import message_user
@@ -34,10 +33,9 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import urlresolvers
 from django.db import IntegrityError, transaction
-from django.utils import safestring
+from django.utils import safestring, timezone
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext as _
-from pytz import utc
 import six
 
 from inboxen.celery import app
@@ -250,7 +248,7 @@ def liberation_finish(result, options):
     user = get_user_model().objects.get(id=options['user'])
     lib_status = user.liberation
     lib_status.flags.running = False
-    lib_status.last_finished = datetime.now(utc)
+    lib_status.last_finished = timezone.now()
     lib_status.content_type = int(options.get('compression_type', '0'))
 
     lib_status.save()

--- a/router/app/helpers.py
+++ b/router/app/helpers.py
@@ -19,10 +19,9 @@
 #
 ##
 
-from datetime import datetime
 import logging
 
-from pytz import utc
+from django.utils import timezone
 from watson import search
 import six
 
@@ -37,7 +36,7 @@ def make_email(message, inbox):
     """Push message to the database.
     """
     base = message.base
-    received_date = datetime.now(utc)
+    received_date = timezone.now()
 
     email = Email(inbox=inbox, received_date=received_date)
     email.save()


### PR DESCRIPTION
Rather than the local variants of now() and fromtimestamp(), use the
utc* variants with replace(tzinfo=utc) (this is what django's
timezone.now does under the hood) as they are ~25% faster than calling
the local versions with utc as an argument.