### PR TITLE
Remove delete email button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Use a more secure method to produce the random part of inboxes (#312)
 * Cleaned up our use of datetime to make sure we're always using timezone away
   datetime objects
+* Removed single delete button from inbox view (#76)
+  * Those buttons are too easy to hit accidentally for an not-undoable action
+    like deleting an email
 
 ## Releases
 

--- a/inboxen/static/js/inbox.js
+++ b/inboxen/static/js/inbox.js
@@ -56,11 +56,9 @@
             complete: function(xhr, statusText) {
                 if (xhr.status === 204) {
                     var $row = $("#email-" + button.value);
+                    // was the important toggle pressed?
                     if (button.name === "important-single") {
                         ToggleImportant($row);
-                        return;
-                    } else if (button.name === "delete-single") {
-                        DeleteRow($row);
                         return;
                     }
 

--- a/inboxen/templates/inboxen/includes/email_line.html
+++ b/inboxen/templates/inboxen/includes/email_line.html
@@ -12,14 +12,14 @@
         </div>
         <div title="{{ received_date|date:"r" }}" class="email-reveived col-xs-5 col-md-1 col-md-push-8">{{ received_date|naturaltime }}</div>
         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
-            <button title="{% trans "Toggle Importantance" %}" class="close" type="submit" name="important-single" value="{{ eid }}">
-                <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Toggle Importantance" %}</span>
-            </button>
             {% if unified %}
             <a class="close" title="{% trans "Inbox" %}" href="{% url 'single-inbox' inbox=inbox domain=domain %}">
                 <span class="fa fa-inbox fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Inbox" %}</span>
             </a>
             {% endif %}
+            <button title="{% trans "Toggle Importantance" %}" class="close" type="submit" name="important-single" value="{{ eid }}">
+                <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Toggle Importantance" %}</span>
+            </button>
         </div>
     </span>
     <a class="clickable" href="{{ email_url }}">

--- a/inboxen/templates/inboxen/includes/email_line.html
+++ b/inboxen/templates/inboxen/includes/email_line.html
@@ -12,9 +12,6 @@
         </div>
         <div title="{{ received_date|date:"r" }}" class="email-reveived col-xs-5 col-md-1 col-md-push-8">{{ received_date|naturaltime }}</div>
         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
-            <button title="{% trans "Delete" %}" class="close" type="submit" name="delete-single" value="{{ eid }}">
-                <span class="fa fa-times fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Delete" %}</span>
-            </button>
             <button title="{% trans "Toggle Importantance" %}" class="close" type="submit" name="important-single" value="{{ eid }}">
                 <span class="fa fa-star fa-lg fa-fw" aria-hidden="true"></span><span class="sr-only">{% trans "Toggle Importantance" %}</span>
             </button>


### PR DESCRIPTION
This fixes #76 by removing the only dangerous (as it is not undoable) button in the email list from the inbox view.

Mostly a cosmetic change as the backend logic is still used by the delete button in the email view. Deleting emails from the inbox view is still possible by using the checkboxes and that big red button at the top of the page.