### PR TITLE
Implement our own version of Django's timesince

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Upgrade to Celery 4 (#222)
 * Do lint checks as part of normal testing
 * Add a copy button to each inbox (#100)
+* Change "X big units, Y small units" times to just "X big units" (#337)
 
 ## Releases
 

--- a/inboxen/templates/inboxen/inbox/email.html
+++ b/inboxen/templates/inboxen/inbox/email.html
@@ -1,6 +1,6 @@
 {# Copyright (c) 2015 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
 {% extends 'inboxen/base.html' %}
-{% load i18n humanize %}
+{% load i18n inboxen_time %}
 
 {% block header %}
     <meta name="referrer" content="same-origin">
@@ -52,7 +52,7 @@
 </div>
 
 <strong>{% trans "From" %}:</strong> {{ email.headers.From }} <br />
-<strong>{% trans "Received" %}:</strong> <span title="{{ email.date|date:"r" }}">{{ email.date|naturaltime }}</span>
+<strong>{% trans "Received" %}:</strong> <span title="{{ email.date|date:"r" }}">{{ email.date|inboxentime }}</span>
 <br />
 {% if headersfetchall %}
 <strong>{% trans "Raw Headers" %}:</strong>

--- a/inboxen/templates/inboxen/includes/email_line.html
+++ b/inboxen/templates/inboxen/includes/email_line.html
@@ -1,5 +1,5 @@
 {# Copyright (c) 2016 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
-{% load i18n inboxen_flags humanize %}
+{% load i18n inboxen_flags inboxen_time %}
 {% url 'email-view' inbox=inbox domain=domain id=eid as email_url %}
 <div id="email-{{ eid }}" class="row">
     <span class="clickable">
@@ -10,7 +10,7 @@
                 <div class="email-flags col-sm-10 col-xs-12">{{ flags|render_flags }}</div>
             </div>
         </div>
-        <div title="{{ received_date|date:"r" }}" class="email-reveived col-xs-5 col-md-1 col-md-push-8">{{ received_date|naturaltime }}</div>
+        <div title="{{ received_date|date:"r" }}" class="email-reveived col-xs-5 col-md-1 col-md-push-8">{{ received_date|inboxentime }}</div>
         <div class="email-buttons col-xs-2 col-md-1 col-md-push-8">
             {% if unified %}
             <a class="close" title="{% trans "Inbox" %}" href="{% url 'single-inbox' inbox=inbox domain=domain %}">

--- a/inboxen/templates/inboxen/includes/inbox_line.html
+++ b/inboxen/templates/inboxen/includes/inbox_line.html
@@ -1,5 +1,5 @@
 {# Copyright (c) 2016 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
-{% load i18n inboxen_flags inboxen_selector humanize %}
+{% load i18n inboxen_flags inboxen_selector inboxen_time %}
 <div id="{{ inbox }}@{{ domain }}" class="row{% if flags.disabled %} inbox-disabled{% endif %}">
     <span class="clickable">
         <div class="{{ col0 }}">
@@ -9,7 +9,7 @@
             </div>
         </div>
         {% if last_activity %}<div class="inbox-activity {{ col2 }}">
-            <span title="{{ last_activity|date:"r" }}">{{ last_activity|naturaltime }}</span>
+            <span title="{{ last_activity|date:"r" }}">{{ last_activity|inboxentime }}</span>
         </div>{% endif %}
         <div class="inbox-options {{ col3 }}">
             <form action="{{ request.path }}" method="POST" data-url="{% url 'form-home' %}"

--- a/inboxen/templatetags/inboxen_time.py
+++ b/inboxen/templatetags/inboxen_time.py
@@ -1,0 +1,104 @@
+##
+#    Copyright (C) 2018 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+from datetime import datetime, timedelta
+import calendar
+
+from django import template
+from django.utils import timezone
+from django.utils.html import avoid_wrapping
+from django.utils.translation import ungettext_lazy, ugettext as _
+
+
+register = template.Library()
+
+
+TIMESINCE_CHUNKS = (
+    (60 * 60 * 24 * 365, ungettext_lazy('a year ago', '%d years ago')),
+    (60 * 60 * 24 * 30, ungettext_lazy('a month ago', '%d months ago')),
+    (60 * 60 * 24 * 7, ungettext_lazy('a week ago', '%d weeks ago')),
+    (60 * 60 * 24, ungettext_lazy('a day ago', '%d days ago')),
+    (60 * 60, ungettext_lazy('a hour ago', '%d hours ago')),
+    (60, ungettext_lazy('a minute ago', '%d minutes ago'))
+)
+
+
+@register.filter(is_safe=False)
+def inboxentime(value):
+    """A filter much like Django's timesince and naturaltime, except it only
+    gives the most significant unit.
+
+    Much of this function was taken from Django 1.11.12
+
+    Copyright (c) Django Software Foundation and individual contributors.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice,
+           this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright
+           notice, this list of conditions and the following disclaimer in the
+           documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of Django nor the names of its contributors may be used
+           to endorse or promote products derived from this software without
+           specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    """
+    if not isinstance(value, datetime):
+        value = datetime(value.year, value.month, value.day)
+
+    now = timezone.now()
+
+    delta = now - value
+
+    # Deal with leapyears by substracting leapdays
+    leapdays = calendar.leapdays(value.year, now.year)
+    if leapdays != 0:
+        if calendar.isleap(value.year):
+            leapdays -= 1
+        elif calendar.isleap(now.year):
+            leapdays += 1
+    delta -= timedelta(leapdays)
+
+    since = delta.days * 24 * 60 * 60 + delta.seconds
+    if since <= 60:
+        # if it's less than a minute ago, it was just now
+        return avoid_wrapping(_("just now"))
+
+    for i, (seconds, name) in enumerate(TIMESINCE_CHUNKS):
+        count = since // seconds
+        if count != 0:
+            break
+
+    name = name % count
+    return avoid_wrapping(name)

--- a/liberation/templates/liberation/liberate.html
+++ b/liberation/templates/liberation/liberate.html
@@ -1,6 +1,6 @@
 {# Copyright (c) 2015 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
 {% extends 'account/index.html' %}
-{% load i18n inboxen_account bootstrap %}
+{% load i18n inboxen_account inboxen_time bootstrap %}
 
 {% block headline %}{% trans "Liberate your data" %}{% endblock %}
 
@@ -11,8 +11,8 @@
 {% block form %}
 {% if object.flags.running %}
     <h4>{% trans "Data liberation is currently running" %}</h4>
-    <p>{% blocktrans with started=object.started|timesince %}
-        Liberation was requested {{ started }} ago and is still pending.
+    <p>{% blocktrans with started=object.started|inboxentime %}
+        Liberation was requested {{ started }} and is still pending.
     {% endblocktrans %}</p>
     <p>{% trans "What's happening right now:" %}</p>
     <ul>
@@ -25,8 +25,8 @@
     {% if object.last_finished %}
     <div class="panel panel-primary">
         <div class="panel-body">
-            <p>{% blocktrans with finished=object.last_finished|timesince %}
-                Your data is available for download. It was generated {{ finished }} ago.
+            <p>{% blocktrans with finished=object.last_finished|inboxentime %}
+                Your data is available for download. It was generated {{ finished }}.
             {% endblocktrans %}</p>
             <a class="btn btn-primary" href="{% url 'user-liberate-get' %}">{% trans "Download" %}</a>
         </div>

--- a/tickets/templates/tickets/admin/response.html
+++ b/tickets/templates/tickets/admin/response.html
@@ -1,6 +1,6 @@
 {# Copyright (c) 2017 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
 {% extends "cms/admin/base.html" %}
-{% load i18n humanize bootstrap %}
+{% load i18n bootstrap inboxen_time %}
 
 {% block headline %}{% trans "Questions" %}{% endblock %}
 
@@ -15,9 +15,9 @@
 <p>
         <b>{% trans "Asked by" %}:</b> {{ question.author.username }}
     <br />
-        <b>{% trans "Asked" %}:</b> <span title="{{ question.date|date:"r" }}">{{ question.date|naturaltime }}</span>
+        <b>{% trans "Asked" %}:</b> <span title="{{ question.date|date:"r" }}">{{ question.date|inboxentime }}</span>
     <br />
-        <b>{% trans "Last activity" %}:</b> <span title="{{ question.last_activity|date:"r" }}">{{ question.last_activity|naturaltime }}</span>
+        <b>{% trans "Last activity" %}:</b> <span title="{{ question.last_activity|date:"r" }}">{{ question.last_activity|inboxentime }}</span>
     <br />
         <b>{% trans "Status" %}:</b> {{ question.get_status_display }}
 </p>

--- a/tickets/templates/tickets/includes/question_list.html
+++ b/tickets/templates/tickets/includes/question_list.html
@@ -1,4 +1,4 @@
-{% load i18n tickets_flags cms_tags humanize %}
+{% load i18n tickets_flags cms_tags inboxen_time %}
 <div class="honeydew">
     <div class="row title hidden-xs">
         <div class="col-sm-6">{% trans "Subject" %}</div>
@@ -17,7 +17,7 @@
             </a>
             <span class="clickable">
                 <div class="col-sm-3 col-xs-3">{{ question.status|render_status }}</div>
-                <div class="col-sm-3 col-xs-9" title="{{ question.last_activity|date:"r" }}">{{ question.last_activity|naturaltime }}</div>
+                <div class="col-sm-3 col-xs-9" title="{{ question.last_activity|date:"r" }}">{{ question.last_activity|inboxentime }}</div>
             </span>
         </div>
         {% if forloop.last and more_url %}

--- a/tickets/templates/tickets/question_detail.html
+++ b/tickets/templates/tickets/question_detail.html
@@ -1,6 +1,6 @@
 {# Copyright (c) 2015 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
 {% extends 'inboxen/base.html' %}
-{% load i18n humanize bootstrap cms_tags %}
+{% load i18n bootstrap cms_tags inboxen_time %}
 
 {% block headline %}{{ object.subject }}{% endblock %}
 
@@ -18,9 +18,9 @@
 <p>
         <b>{% trans "Asked by" %}:</b> {{ object.author.username }}
     <br />
-        <b>{% trans "Asked" %}:</b> <span title="{{ object.date|date:"r" }}">{{ object.date|naturaltime }}</span>
+        <b>{% trans "Asked" %}:</b> <span title="{{ object.date|date:"r" }}">{{ object.date|inboxentime }}</span>
     <br />
-        <b>{% trans "Last activity" %}:</b> <span title="{{ object.last_activity|date:"r" }}">{{ object.last_activity|naturaltime }}</span>
+        <b>{% trans "Last activity" %}:</b> <span title="{{ object.last_activity|date:"r" }}">{{ object.last_activity|inboxentime }}</span>
     <br />
         <b>{% trans "Status" %}:</b> {{ object.get_status_display }}
 </p>

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -81,9 +81,9 @@ class QuestionViewTestCase(InboxenTestCase):
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn("More Questions", str(response.content))
+        self.assertIn("More Questions", response.content.decode("utf-8"))
         list_url = app_reverse(self.page, "tickets-list", kwargs={"status": "open"})
-        self.assertIn(list_url, str(response.content))
+        self.assertIn(list_url, response.content.decode("utf-8"))
 
     def test_switch_open_closed(self):
         models.Question.objects.filter(status=models.Question.NEW).update(author=self.other_user)
@@ -92,9 +92,9 @@ class QuestionViewTestCase(InboxenTestCase):
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn("More Questions", str(response.content))
+        self.assertIn("More Questions", response.content.decode("utf-8"))
         list_url = app_reverse(self.page, "tickets-list", kwargs={"status": "closed"})
-        self.assertIn(list_url, str(response.content))
+        self.assertIn(list_url, response.content.decode("utf-8"))
 
     def test_post_form_valid(self):
         params = {"subject": "Hello!", "body": "This is the body of my question"}
@@ -168,7 +168,7 @@ class QuestionDetailTestCase(InboxenTestCase):
     def test_get(self):
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
-        self.assertIn(self.question.render_body(), str(response.content))
+        self.assertIn(self.question.render_body(), response.content.decode("utf-8"))
 
     def test_post_form_valid(self):
         response = self.client.post(self.get_url(), {"body": "hello"}, follow=True)
@@ -180,7 +180,7 @@ class QuestionDetailTestCase(InboxenTestCase):
         self.assertEqual(responses[0].body, "hello")
 
         response = self.client.get(self.get_url())
-        self.assertIn(responses[0].render_body(), str(response.content))
+        self.assertIn(responses[0].render_body(), response.content.decode("utf-8"))
 
     def test_post_form_invalid(self):
         response_count = models.Response.objects.all().count()


### PR DESCRIPTION
Only display the most significant time unit, e.g. "3 hours ago", not "3
hours, 10 minutes ago"

Fixes #337