### PR TITLE
Make ChartJS graphs responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Rate limit user registration (#342)
 * Change "X big units, Y small units" times to just "X big units" (#337)
 * Fix button column width on home view (#338)
+* Fix responsiveness of stats charts (#341)
 
 ## Releases
 

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -21,6 +21,9 @@ $font-family-monospace:   monospace;
 
 $profile-margin: 10px;
 $honeydew-button-size: 1em;
+// width is relative to viewport size, so add in some slack to account for
+// gutters, etc.
+$chart-width: 90vw;
 
 html {
     position: relative;
@@ -276,8 +279,14 @@ a.soon {
     @include button-size(20px, 32px, 28px, 1.0, 6px);
 }
 
-.chart canvas {
+.chart {
+    position: relative;
+    width: $chart-width;
     height: 250px !important;
+
+    @media (min-width: $screen-md-min) {
+        width: $chart-width / 3;
+    }
 }
 
 .line-legend {

--- a/inboxen/templates/inboxen/stats.html
+++ b/inboxen/templates/inboxen/stats.html
@@ -22,7 +22,7 @@
             <tr class="active">
                 <th colspan="2">{% trans "Users" %}</th>
             </tr>
-            <tr><td colspan="2" id="users-chart" class="chart"></td></tr>
+            <tr><td colspan="2"><div id="users-chart" class="chart"></div></td></tr>
             <tr>
                 <th>{% trans "User count" %}</th>
                 <td>
@@ -51,7 +51,7 @@
             <tr class="active">
                 <th colspan="2">{% trans "Inboxes" %}</th>
             </tr>
-            <tr><td colspan="2" id="inboxes-chart" class="chart"></td></tr>
+            <tr><td colspan="2"><div id="inboxes-chart" class="chart"></div></td></tr>
             <tr>
                 <th>{% trans "Total number of inboxes" %}</th>
                 <td>
@@ -82,7 +82,7 @@
             <tr class="active">
                 <th colspan="2">{% trans "Emails" %}</th>
             </tr>
-            <tr><td colspan="2" id="emails-chart" class="chart"></td></tr>
+            <tr><td colspan="2"><div id="emails-chart" class="chart"></div></td></tr>
             <tr>
                 <th>{% trans "Total number of emails" %}</th>
                 <td>


### PR DESCRIPTION
Previously, this had not been the case.

Notes:
* The current version of ChartJS requires unsafe-line for styles: https://github.com/chartjs/Chart.js/issues/5208
* ~~The resize event fires multiple times creating something that looks like animation (but isn't because that's been disabled.~~ Fixed with a work around.