### PR TITLE
Use immutable id for cache key, not username

### DIFF
--- a/inboxen/utils/ratelimit.py
+++ b/inboxen/utils/ratelimit.py
@@ -61,7 +61,7 @@ class RateLimit(object):
 def make_key(request, dt):
     key = "{}{}-{}".format(
         settings.INBOX_LIMIT_CACHE_PREFIX,
-        request.user.username,
+        request.user.id,
         dt.strftime("%Y%m%d%H%M"),
     )
 


### PR DESCRIPTION
A better fix for #354

Users can change their username and bypass ratelimiting!