### PR TITLE
Make attachment names readable again

### DIFF
--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -279,6 +279,15 @@ a.soon {
     display: flex;
     flex-wrap: wrap;
 
+    & > * {
+        margin-bottom: 20px;
+    }
+
+    .panel {
+        height: 100%;
+        margin-bottom: 0px;
+    }
+
     .panel-body {
         word-wrap: break-word;
     }

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -278,12 +278,10 @@ a.soon {
 .attachments {
     display: flex;
     flex-wrap: wrap;
-}
-.attachments > div {
-    width: 25%;
-}
-.attachments .panel-body {
-    word-wrap: break-word;
+
+    .panel-body {
+        word-wrap: break-word;
+    }
 }
 
 .btn-massive {

--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -275,6 +275,17 @@ a.soon {
     white-space: nowrap;
 }
 
+.attachments {
+    display: flex;
+    flex-wrap: wrap;
+}
+.attachments > div {
+    width: 25%;
+}
+.attachments .panel-body {
+    word-wrap: break-word;
+}
+
 .btn-massive {
     @include button-size(20px, 32px, 28px, 1.0, 6px);
 }

--- a/inboxen/templates/inboxen/inbox/email.html
+++ b/inboxen/templates/inboxen/inbox/email.html
@@ -66,7 +66,7 @@
 {% endfor %}
 <br />
 <strong>{% trans "Attachments" %}</strong>
-<div>
+<div class="attachments">
 {% include "inboxen/includes/attachment.html" with attachment=attachments %}
 </div>
 {% endblock %}

--- a/inboxen/templates/inboxen/includes/attachment.html
+++ b/inboxen/templates/inboxen/includes/attachment.html
@@ -10,7 +10,7 @@
                     </a>
                 </div>
             </div>
-            <div class="panel-body overflow-text">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
+            <div class="panel-body">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
         </div>
     </div>
 {% else %}


### PR DESCRIPTION
This returns to not truncating the names and content-types of attachments (because I got an email with four different attachments all of whose names started with the same 45 characters), but arranges the attachment panels using a flex layout so they don't get all janky when they have different heights.

This was only tested by modifying a saved standalone HTML page, and not on a running Inboxen instance. But I'm a very stable genius, so it's a beautiful commit, believe me. The best commit.