### PR TITLE
Give cancel buttons on inline forms a href

### DIFF
--- a/inboxen/templates/inboxen/forms/inbox/add.html
+++ b/inboxen/templates/inboxen/forms/inbox/add.html
@@ -4,5 +4,5 @@
     {% csrf_token %}
     {{ form|bootstrap }}
     <button class="btn btn-primary">{% trans "Add" %}</button>
-    <a class="btn btn-default">{% trans "Cancel" %}</a>
+    <a href="#navbar-container" class="btn btn-default">{% trans "Cancel" %}</a>
 </form>

--- a/inboxen/templates/inboxen/forms/inbox/edit.html
+++ b/inboxen/templates/inboxen/forms/inbox/edit.html
@@ -17,5 +17,5 @@
         </div>
     </div>
     <button class="btn btn-primary">{% trans "Save" %}</button>
-    <a class="btn btn-default">{% trans "Cancel" %}</a>
+    <a href="#{{ inbox.inbox }}@{{ inbox.domain.domain }}" class="btn btn-default">{% trans "Cancel" %}</a>
 </form>

--- a/inboxen/templates/inboxen/inbox/inbox.html
+++ b/inboxen/templates/inboxen/inbox/inbox.html
@@ -5,7 +5,7 @@
 {% block headline %}{{ headline }}{% endblock %}
 
 {% block breadcumbs %}
-    <ul class="breadcrumb">
+    <ul id="{{ inbox }}@{{ domain }}" class="breadcrumb">
         <li><a href="{% url 'user-home' %}">{% blocktrans %} {{ user }}'s Home {% endblocktrans %}</a></li>
         {% if inbox %}
             <li class="active">{{ inbox }}@{{ domain }}</li>


### PR DESCRIPTION
Without a href, browsers will skip the cancel buttons when attempting to
use keyboard

Fixes #382