### PR TITLE
Make attachment names readable again - take two

### DIFF
--- a/inboxen/static/css/inboxen.scss
+++ b/inboxen/static/css/inboxen.scss
@@ -261,6 +261,39 @@ a.soon {
     line-height: 50px;
 }
 
+.attachments {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    .attachment {
+        width: 100%;
+        padding: ceil(($grid-gutter-width / 2));
+        flex: 1 0 auto;
+
+        overflow-wrap: break-word;
+        hyphens: none;
+        white-space: normal;
+
+        @media (min-width: $screen-sm-min) {
+            width: calc(100% / 3);
+        }
+
+        @media (min-width: $screen-md-min) {
+            width: 25%;
+        }
+
+        @media (min-width: $screen-lg-min) {
+            width: calc(100% / 6);
+        }
+
+        .panel {
+            height: 100%;
+            margin: 0;
+        }
+    }
+}
+
 .clear-gap {
     padding-bottom: 50px;
 }

--- a/inboxen/templates/inboxen/inbox/email.html
+++ b/inboxen/templates/inboxen/inbox/email.html
@@ -66,7 +66,7 @@
 {% endfor %}
 <br />
 <strong>{% trans "Attachments" %}</strong>
-<div>
+<div class="attachments">
 {% include "inboxen/includes/attachment.html" with attachment=attachments %}
 </div>
 {% endblock %}

--- a/inboxen/templates/inboxen/includes/attachment.html
+++ b/inboxen/templates/inboxen/includes/attachment.html
@@ -1,7 +1,7 @@
 {# Copyright (c) 2017 Jessica Tallon & Matt Molyneaux. This file is part of Inboxen. Licensed under the terms of the GNU AGPL, as published by the FSF, version 3 the or later #}
 {% load i18n %}
 {% if attachment.is_leaf_node %}
-    <div class="col-sm-4 col-md-3 col-lg-2">
+    <div class="attachment">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="btn-group btn-group-justified" role="group">
@@ -10,7 +10,7 @@
                     </a>
                 </div>
             </div>
-            <div class="panel-body overflow-text">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
+            <div class="panel-body">{{ attachment.filename }} ({{ attachment.content_type|default:"text/plain" }})</div>
         </div>
     </div>
 {% else %}

--- a/inboxen/templates/inboxen/styleguide.html
+++ b/inboxen/templates/inboxen/styleguide.html
@@ -221,7 +221,7 @@
         </div>
         <div class="container-fluid">
             <h2>MIME part download</h2>
-            <div class="row">
+            <div class="attachments">
                 {% for attachment in attachments %}
                     {% include "inboxen/includes/attachment.html" with attachment=attachment %}
                 {% endfor %}


### PR DESCRIPTION
Based on PR #379 but cleaned up to use Bootstrap variables used elsewhere and to be more consistent with the rest of the "design".

@xray7224 what do you think?

Large screen, showing one row at the minimum height and an expanded second row and text wrapping
![screenshot from 2019-01-09 23-57-56](https://user-images.githubusercontent.com/1490673/50937319-020d6800-146b-11e9-9799-5508ceef5362.png)

Small screen, showing the single column view
![screenshot from 2019-01-09 23-58-19](https://user-images.githubusercontent.com/1490673/50937324-076ab280-146b-11e9-83be-480a8f5dc430.png)

