### PR TITLE
Revert "Put webassets manifest in a place where webassets can find it"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ docs/_build
 /static_content
 /media_content
 /node_modules
-/.webassets-manifest
 
 # local requirements
 /local-reqs.txt

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -50,8 +50,6 @@ INBOX_AUTO_DELETE_TIME = 30
 # assets building options
 ASSETS_DEBUG = DEBUG  # noqa: F405
 ASSETS_AUTO_BUILD = DEBUG  # noqa: F405
-ASSETS_MANIFEST = "file:{}".format(os.path.join(BASE_DIR, ".webassets-manifest"))  # noqa: F405
-
 ##
 # Celery options
 ##


### PR DESCRIPTION
Reverts Inboxen/Inboxen#406

The result of #407 is that we don't need this change anymore. Put it back to default.