### PR TITLE
Log filter for salmon

### DIFF
--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -299,6 +299,9 @@ LOGGING = {
         'require_debug_true': {
             '()': 'django.utils.log.RequireDebugTrue',
         },
+        'is_not_salmon': {
+            '()': 'inboxen.utils.log.IsNotSalmon',
+        },
     },
     'handlers': {
         'console': {
@@ -307,7 +310,7 @@ LOGGING = {
         },
         'mail_admins': {
             'level': 'ERROR',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'is_not_salmon'],
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },

--- a/inboxen/utils/log.py
+++ b/inboxen/utils/log.py
@@ -1,0 +1,34 @@
+##
+#    Copyright (C) 2019 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+import inspect
+import logging
+
+
+IS_SALMON = inspect.stack()[-1][1].endswith("salmon")
+
+
+class IsSalmon(logging.Filter):
+    def filter(self, record):
+        return not IS_SALMON
+
+
+class IsNotSalmon(logging.Filter):
+    def filter(self, record):
+        return not IS_SALMON


### PR DESCRIPTION
This will prevent Salmon from emailing admins when there is an error. It
should only be logging to the log file.