### PR TITLE
Update versioneer config

### DIFF
--- a/inboxen/_version.py
+++ b/inboxen/_version.py
@@ -40,8 +40,8 @@ def get_config():
     # _version.py
     cfg = VersioneerConfig()
     cfg.VCS = "git"
-    cfg.style = "pep440"
-    cfg.tag_prefix = "inboxen-"
+    cfg.style = "git-describe-long"
+    cfg.tag_prefix = ""
     cfg.parentdir_prefix = "inboxen-"
     cfg.versionfile_source = "inboxen/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
Apparently it needs updating any time setup.cfg changed.

*This* actually solves the issue where the version doesn't contain git tag information. :upside_down_face: 