### PR TITLE
Remove unused dependencies

### DIFF
--- a/extra/requirements/watermelon.inboxen.org.txt
+++ b/extra/requirements/watermelon.inboxen.org.txt
@@ -40,7 +40,6 @@ docutils==0.14            # via python-daemon
 factory-boy==2.12.0
 faker==0.8.5              # via factory-boy
 idna==2.8                 # via requests
-ipaddress==1.0.22
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.5.0
 jedi==0.13.3              # via ipython

--- a/extra/requirements/watermelon.inboxen.org.txt
+++ b/extra/requirements/watermelon.inboxen.org.txt
@@ -24,7 +24,6 @@ django-annoying==0.10.4
 django-assets==0.12
 django-async-messages==0.3.1
 django-bootstrap-form==3.4
-django-braces==1.13.0
 django-csp==3.5
 django-cursor-pagination==0.1.4
 django-elevate==1.0.0

--- a/extra/requirements/watermelon.inboxen.org.txt
+++ b/extra/requirements/watermelon.inboxen.org.txt
@@ -22,7 +22,6 @@ cssutils==1.0.2           # via premailer
 decorator==4.4.0          # via ipython, traitlets
 django-annoying==0.10.4
 django-assets==0.12
-django-async-messages==0.3.1
 django-bootstrap-form==3.4
 django-csp==3.5
 django-cursor-pagination==0.1.4
@@ -35,7 +34,7 @@ django-otp==0.6.0
 django-phonenumber-field==1.3.0
 django-ratelimit-backend==2.0
 django-sendfile2==0.4.2
-django==2.2.1             # via django-annoying, django-assets, django-async-messages, django-bootstrap-form, django-csp, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
+django==2.2.1             # via django-annoying, django-assets, django-bootstrap-form, django-csp, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
 dnspython==1.16.0         # via salmon-mail
 docutils==0.14            # via python-daemon
 factory-boy==2.12.0

--- a/inboxen/account/views/delete.py
+++ b/inboxen/account/views/delete.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views import generic
 from elevate.mixins import ElevateMixin

--- a/inboxen/account/views/settings.py
+++ b/inboxen/account/views/settings.py
@@ -17,8 +17,8 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
 from django.contrib.auth import views as auth_views
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views import generic
 from elevate.mixins import ElevateMixin

--- a/inboxen/liberation/views.py
+++ b/inboxen/liberation/views.py
@@ -17,9 +17,9 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
 from django import http
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views import generic

--- a/inboxen/tickets/views.py
+++ b/inboxen/tickets/views.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Count, Max
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse

--- a/inboxen/views/inbox/add.py
+++ b/inboxen/views/inbox/add.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views import generic
 

--- a/inboxen/views/inbox/attachment.py
+++ b/inboxen/views/inbox/attachment.py
@@ -17,7 +17,7 @@
 
 import re
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponse
 from django.views import generic
 

--- a/inboxen/views/inbox/edit.py
+++ b/inboxen/views/inbox/edit.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404
 from django.urls import Resolver404, resolve, reverse, reverse_lazy
 from django.views import generic

--- a/inboxen/views/inbox/email.py
+++ b/inboxen/views/inbox/email.py
@@ -19,7 +19,7 @@
 
 import logging
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.http import HttpResponseRedirect
 from django.views import generic

--- a/inboxen/views/inbox/inbox.py
+++ b/inboxen/views/inbox/inbox.py
@@ -17,7 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.http import Http404, HttpResponseNotAllowed, HttpResponseRedirect
 from django.utils.translation import ugettext as _

--- a/inboxen/views/user/home.py
+++ b/inboxen/views/user/home.py
@@ -18,7 +18,7 @@
 ##
 
 
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponseNotAllowed, HttpResponseRedirect
 from django.views import generic
 from watson import search

--- a/inboxen/views/user/search.py
+++ b/inboxen/views/user/search.py
@@ -17,11 +17,11 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-from braces.views import LoginRequiredMixin
 from celery import exceptions
 from celery.result import AsyncResult
 from django import http
 from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db.models import Case, When

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,6 @@ django-annoying==0.10.4
 django-assets==0.12
 django-async-messages==0.3.1
 django-bootstrap-form==3.4
-django-braces==1.13.0
 django-csp==3.5
 django-cursor-pagination==0.1.4
 django-debug-toolbar==1.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,6 @@ cssutils==1.0.2           # via premailer
 decorator==4.4.0          # via ipython, traitlets
 django-annoying==0.10.4
 django-assets==0.12
-django-async-messages==0.3.1
 django-bootstrap-form==3.4
 django-csp==3.5
 django-cursor-pagination==0.1.4
@@ -40,7 +39,7 @@ django-otp==0.6.0
 django-phonenumber-field==1.3.0
 django-ratelimit-backend==2.0
 django-sendfile2==0.4.2
-django==2.2.1             # via django-annoying, django-assets, django-async-messages, django-bootstrap-form, django-csp, django-debug-toolbar, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
+django==2.2.1             # via django-annoying, django-assets, django-bootstrap-form, django-csp, django-debug-toolbar, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
 dnspython==1.16.0         # via salmon-mail
 docutils==0.14            # via python-daemon
 factory-boy==2.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,6 @@ faker==0.8.5              # via factory-boy
 filelock==3.0.12          # via tox
 glob2==0.6                # via jasmine-core
 idna==2.8                 # via requests
-ipaddress==1.0.22
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.5.0
 isort==4.3.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 django-annoying==0.10.4
 django-assets==0.12
-django-async-messages==0.3.1
 django-bootstrap-form==3.4
 django-csp==3.5
 django-cursor-pagination==0.1.4
@@ -33,7 +32,7 @@ django-otp==0.6.0
 django-phonenumber-field==1.3.0
 django-ratelimit-backend==2.0
 django-sendfile2==0.4.2
-django==2.2.1             # via django-annoying, django-assets, django-async-messages, django-bootstrap-form, django-csp, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
+django==2.2.1             # via django-annoying, django-assets, django-bootstrap-form, django-csp, django-formtools, django-mptt, django-otp, django-phonenumber-field, django-ratelimit-backend, django-sendfile2
 dnspython==1.16.0         # via salmon-mail
 docutils==0.14            # via python-daemon
 factory-boy==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ django-annoying==0.10.4
 django-assets==0.12
 django-async-messages==0.3.1
 django-bootstrap-form==3.4
-django-braces==1.13.0
 django-csp==3.5
 django-cursor-pagination==0.1.4
 django-elevate==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ docutils==0.14            # via python-daemon
 factory-boy==2.12.0
 faker==0.8.5              # via factory-boy
 idna==2.8                 # via requests
-ipaddress==1.0.22
 jsmin==2.2.2
 kombu==4.5.0              # via celery
 lmtpd==6.0.0              # via salmon-mail

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "configobj",
         "django-annoying",
         "django-assets",
-        "django-async-messages",
         "django-bootstrap-form",
         "django-csp>3.0",
         "django-cursor-pagination",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "django-assets",
         "django-async-messages",
         "django-bootstrap-form",
-        "django-braces",
         "django-csp>3.0",
         "django-cursor-pagination",
         "django-extensions",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         # 0.8.6 and later require text-unidecode, which is incompatible with the AGPL :(
         "faker==0.8.5",
         "factory-boy",
-        "ipaddress",
         "jsmin",
         "lxml",
         # make sure django-phonenumbers uses the smaller package

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "django-csp>3.0",
         "django-cursor-pagination",
         "django-extensions",
-        "django-formtools",
         "django-mptt",
         "django-otp",
         "django-ratelimit-backend",


### PR DESCRIPTION
* braces: LoginRequiredMixin is now in Django itself
* formtools: not a direct dependency
* django-async-messages: not compatible with Django 2.2
* ipaddress: this is a backport of the Python 3.3 package, we're no longer on Python 2.7 so we don't need it any more