### PR TITLE
Convert some tags to div rather than simply dropping them

### DIFF
--- a/inboxen/tests/example_emails.py
+++ b/inboxen/tests/example_emails.py
@@ -24,6 +24,7 @@ BODY = u"""<html>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <style type="text/css">
 p {color: #ffffff;background:transparent url(<a href="http://cdn-images.mailchimp.com/awesomebar-sprite.png">http://cdn-images.mailchimp.com/awesomebar-sprite.png</a>) 0 -200px;}
+body {background-color: red;}
 </style>
 <script><!-- console.log("I'm a bad email") --></script>
 </head>

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -78,6 +78,7 @@ class EmailViewTestCase(InboxenTestCase):
 
         # check that premailer removes invalid CSS
         self.assertNotIn("awesomebar-sprite.png", response.content.decode("utf-8"))
+        self.assertIn("background-color: red", response.content.decode("utf-8"))
 
         # check for same-origin
         self.assertIn('<meta name="referrer" content="same-origin">', response.content.decode("utf-8"))
@@ -481,6 +482,28 @@ class UtilityTestCase(InboxenTestCase):
 
         # empty tags should not have their closing tag removed
         returned_body = email_utils._clean_html_body(None, email, EMPTY_ANCHOR_TAG, "ascii")
+        self.assertEqual(returned_body, expected_html)
+
+    def test_body_tag_get_turned_to_div(self):
+        email = {"display_images": True, "eid": "abc"}
+        expected_html = "".join([
+            """<div><div style="hi"><a href="/click/?url=https%3A//example.com" target="_blank" """,
+            """rel="noreferrer"></a></div></div>""",
+        ])
+
+        text = """<html><body style="hi">{}</body></html>""".format(EMPTY_ANCHOR_TAG)
+        returned_body = email_utils._clean_html_body(None, email, text, "ascii")
+        self.assertEqual(returned_body, expected_html)
+
+    def test_unknown_tag_get_dropped(self):
+        email = {"display_images": True, "eid": "abc"}
+        expected_html = "".join([
+            """<div><div><a href="/click/?url=https%3A//example.com" target="_blank" """,
+            """rel="noreferrer"></a></div></div>""",
+        ])
+
+        text = """<html><body><section style="hi">{}</section></body></html>""".format(EMPTY_ANCHOR_TAG)
+        returned_body = email_utils._clean_html_body(None, email, text, "ascii")
         self.assertEqual(returned_body, expected_html)
 
     def test_render_body_bad_encoding(self):

--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -78,7 +78,7 @@ class EmailViewTestCase(InboxenTestCase):
 
         # check that premailer removes invalid CSS
         self.assertNotIn("awesomebar-sprite.png", response.content.decode("utf-8"))
-        self.assertIn("background-color: red", response.content.decode("utf-8"))
+        self.assertIn("<div style=\"background-color:red\">", response.content.decode("utf-8"))
 
         # check for same-origin
         self.assertIn('<meta name="referrer" content="same-origin">', response.content.decode("utf-8"))


### PR DESCRIPTION
At the moment this is only `body`, but can be expanded to other tags if required.

Fixes #404 