### PR TITLE
Cast memory object to bytes, not repr as HttpResponse does

### DIFF
--- a/inboxen/tests/test_email.py
+++ b/inboxen/tests/test_email.py
@@ -437,6 +437,12 @@ class AttachmentTestCase(InboxenTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Disposition"], "attachment; filename=\"Växjö.jpg\"")
 
+    def test_body_is_in_response(self):
+        url = urls.reverse("email-attachment", kwargs={"attachmentid": self.part.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, BODY)
+
 
 class UtilityTestCase(InboxenTestCase):
     def test_is_unicode(self):

--- a/inboxen/views/inbox/attachment.py
+++ b/inboxen/views/inbox/attachment.py
@@ -59,7 +59,7 @@ class AttachmentDownloadView(LoginRequiredMixin, generic.detail.BaseDetailView):
             content_type = "application/octet-stream"
 
         # make header object
-        data = self.object.body.data or ""
+        data = bytes(self.object.body.data)
         response = HttpResponse(
             content=data,
             status=200,


### PR DESCRIPTION
Also, add a test

Fixes #437