### PR TITLE
fix change password view not redirecting correctly

### DIFF
--- a/inboxen/account/views/settings.py
+++ b/inboxen/account/views/settings.py
@@ -62,8 +62,8 @@ class UsernameChangeView(LoginRequiredMixin, ElevateMixin, generic.FormView):
 
 
 class PasswordChangeView(auth_views.PasswordChangeView):  # PasswordChangeView already checks loggedin-ness
-    password_change_form = forms.PlaceHolderPasswordChangeForm
-    post_change_redirect = reverse_lazy('user-security')
+    form_class = forms.PlaceHolderPasswordChangeForm
+    success_url = reverse_lazy('user-security')
     template_name = 'account/password.html'
 
 


### PR DESCRIPTION
This was caused by a minor oversight where Django 1.11 and 2.2 used
different names for overriding the redirect as well as the form class
itself

Fixes #441