### PR TITLE
Salmon server should be started via boot not settings

### DIFF
--- a/inboxen/router/config/boot.py
+++ b/inboxen/router/config/boot.py
@@ -24,6 +24,7 @@ import os
 from django.conf import settings as dj_settings
 from salmon import queue
 from salmon.routing import Router
+from salmon.server import LMTPReceiver, SMTPReceiver
 
 from inboxen.router.config import settings
 
@@ -40,6 +41,13 @@ except OSError:
     pass
 
 logging.config.dictConfig(dj_settings.SALMON_LOGGING)
+
+# where to listen for incoming messages
+if dj_settings.SALMON_SERVER["type"] == "lmtp":
+    receiver = LMTPReceiver(socket=dj_settings.SALMON_SERVER["path"])
+elif dj_settings.SALMON_SERVER["type"] == "smtp":
+    receiver = SMTPReceiver(dj_settings.SALMON_SERVER['host'],
+                            dj_settings.SALMON_SERVER['port'])
 
 Router.load(['inboxen.router.app.server'])
 Router.RELOAD = False

--- a/inboxen/router/config/settings.py
+++ b/inboxen/router/config/settings.py
@@ -1,16 +1,7 @@
 import os
 
-from django.conf import settings  # noqa
-from salmon.server import LMTPReceiver, SMTPReceiver
-import django  # noqa
+import django
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'inboxen.settings'
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inboxen.settings')
 
 django.setup()
-
-# where to listen for incoming messages
-if settings.SALMON_SERVER["type"] == "lmtp":
-    receiver = LMTPReceiver(socket=settings.SALMON_SERVER["path"])
-elif settings.SALMON_SERVER["type"] == "smtp":
-    receiver = SMTPReceiver(settings.SALMON_SERVER['host'],
-                            settings.SALMON_SERVER['port'])


### PR DESCRIPTION
This corrects a minor error that could lead to Salmon starting a server
when it didn't mean to. Currently this isn't actually a problem because
the only command other than "start" that could load settings is broken:
https://github.com/moggers87/salmon/issues/102