### PR TITLE
Fix salmon config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ salmon-stop:
 .PHONY: salmon-start
 salmon-start:
 	SALMON_SETTINGS_MODULE=inboxen.router.config.settings salmon start --pid run/router.pid --boot inboxen.router.config.boot
+	sleep 5
+	SALMON_SETTINGS_MODULE=inboxen.router.config.settings salmon status --pid run/router.pid
 
 ##
 #	Inboxen.org specific tasks

--- a/inboxen/router/config/boot.py
+++ b/inboxen/router/config/boot.py
@@ -44,10 +44,10 @@ logging.config.dictConfig(dj_settings.SALMON_LOGGING)
 
 # where to listen for incoming messages
 if dj_settings.SALMON_SERVER["type"] == "lmtp":
-    receiver = LMTPReceiver(socket=dj_settings.SALMON_SERVER["path"])
+    settings.receiver = LMTPReceiver(socket=dj_settings.SALMON_SERVER["path"])
 elif dj_settings.SALMON_SERVER["type"] == "smtp":
-    receiver = SMTPReceiver(dj_settings.SALMON_SERVER['host'],
-                            dj_settings.SALMON_SERVER['port'])
+    settings.receiver = SMTPReceiver(dj_settings.SALMON_SERVER['host'],
+                                     dj_settings.SALMON_SERVER['port'])
 
 Router.load(['inboxen.router.app.server'])
 Router.RELOAD = False


### PR DESCRIPTION
Boot module should populate `settings.receiver`

Also, check Salmon is actually running and hasn't simply exited as soon as it daemonised.