### PR TITLE
Prevent flex from expanding attachments

### DIFF
--- a/frontend/css/inboxen.scss
+++ b/frontend/css/inboxen.scss
@@ -269,7 +269,8 @@ a.soon {
     .attachment {
         width: 100%;
         padding: ceil(($grid-gutter-width / 2));
-        flex: 1 0 auto;
+        flex: none;
+        min-width: 300px;
 
         overflow-wrap: break-word;
         hyphens: none;


### PR DESCRIPTION
Also given attachments a min-width to prevent the opposite problem

Fix #458