### PR TITLE
create_search_cache_key should also accept a model name

### DIFF
--- a/inboxen/search/tasks.py
+++ b/inboxen/search/tasks.py
@@ -67,7 +67,7 @@ def search(user_id, search_term, model, before=None, after=None):
         results["last"] = paginator.cursor(page[-1])
         results["first"] = paginator.cursor(page[0])
 
-    key = create_search_cache_key(user_id, search_term, before, after)
+    key = create_search_cache_key(user_id, search_term, model, before, after)
     cache.set(key, results, SEARCH_TIMEOUT)
 
     return results

--- a/inboxen/search/tests/test_views.py
+++ b/inboxen/search/tests/test_views.py
@@ -36,7 +36,7 @@ class SearchApiViewTestCase(InboxenTestCase):
 
         login = self.client.login(username=self.user.username, password="123456", request=MockRequest(self.user))
 
-        self.key = create_search_cache_key(self.user.id, "cheddår", None, None)
+        self.key = create_search_cache_key(self.user.id, "cheddår", "inboxen.Inbox",  None, None)
         self.url = "%s?token=%s" % (
             urls.reverse("search:api"),
             self.key,

--- a/inboxen/search/utils.py
+++ b/inboxen/search/utils.py
@@ -22,8 +22,15 @@ import base64
 SEARCH_VERSION = 1  # bump this any time you change how the cache key workds
 
 
-def create_search_cache_key(user_id, search_term, before, after):
-    key = "{}{}{}{}{}".format(SEARCH_VERSION, user_id, before, after, search_term)
+def create_search_cache_key(user_id, query, model, before, after):
+    key = "{version}{user}{model}{before}{after}{query}".format(
+        version=SEARCH_VERSION,
+        user=user_id,
+        model=model,
+        before=before,
+        after=after,
+        query=query,
+    )
     key = base64.b64encode(key.encode()).decode()
 
     return key

--- a/inboxen/search/views.py
+++ b/inboxen/search/views.py
@@ -40,7 +40,8 @@ class SearchMixin:
         return super().dispatch(request, *args, **kwargs)
 
     def get_cache_key(self):
-        return create_search_cache_key(self.request.user.id, self.query, self.first_item, self.last_item)
+        return create_search_cache_key(self.request.user.id, self.query, self.model._meta.label,
+                                       self.first_item, self.last_item)
 
     @cached_property
     def results(self):

--- a/inboxen/tests/test_home.py
+++ b/inboxen/tests/test_home.py
@@ -215,7 +215,7 @@ class SearchViewTestCase(InboxenTestCase):
         login = self.client.login(username=self.user.username, password="123456", request=MockRequest(self.user))
 
         self.url = urls.reverse("user-home-search", kwargs={"q": "cheddär"})
-        self.key = create_search_cache_key(self.user.id, "cheddär", None, None)
+        self.key = create_search_cache_key(self.user.id, "cheddär", models.Inbox._meta.label, None, None)
 
         if not login:
             raise Exception("Could not log in")

--- a/inboxen/tests/test_inbox.py
+++ b/inboxen/tests/test_inbox.py
@@ -571,7 +571,7 @@ class SearchViewTestCase(InboxenTestCase):
         self.url = urls.reverse("single-inbox-search", kwargs={"q": "cheddär",
                                                                "inbox": self.inbox.inbox,
                                                                "domain": self.inbox.domain.domain})
-        self.key = create_search_cache_key(self.user.id, "cheddär", None, None)
+        self.key = create_search_cache_key(self.user.id, "cheddär", models.Email._meta.label, None, None)
 
         if not login:
             raise Exception("Could not log in")


### PR DESCRIPTION
Avoids clashes between two searches on different models with the same
search term, before, after, and user.