### PR TITLE
Restore update_last_login signal

### DIFF
--- a/inboxen/apps.py
+++ b/inboxen/apps.py
@@ -25,12 +25,9 @@ class InboxenConfig(AppConfig):
     verbose_name = "Inboxen Core"
 
     def ready(self):
-        from django.contrib.auth.signals import user_logged_in, user_logged_out
+        from django.contrib.auth.signals import user_logged_out
 
         from inboxen import checks  # noqa
         from inboxen import signals
-
-        # Unregister update_last_login handler
-        assert user_logged_in.disconnect(dispatch_uid='update_last_login'), "Last login not disconnected"
 
         user_logged_out.connect(signals.logout_message, dispatch_uid='inboxen_logout_message')

--- a/inboxen/tests/test_misc.py
+++ b/inboxen/tests/test_misc.py
@@ -83,7 +83,7 @@ class LoginTestCase(InboxenTestCase):
         self.assertEqual(login, True)
 
         user = get_user_model().objects.get(id=self.user.id)
-        self.assertEqual(user.last_login, None)
+        self.assertNotEqual(user.last_login, None)
 
     def test_normal_login(self):
         response = self.client.get(urls.reverse("user-home"))


### PR DESCRIPTION
Before doing anything about #444 we should at least have some data on who is and isn't logging in.