### PR TITLE
Set flags new flags when emails are deleted

### DIFF
--- a/inboxen/forms/inbox.py
+++ b/inboxen/forms/inbox.py
@@ -98,8 +98,7 @@ class InboxEditForm(forms.ModelForm):
         clear_inbox = data.pop("clear_inbox", False)
 
         if clear_inbox:
-            emails = self.instance.email_set.all()
-            emails.update(deleted=True)
+            tasks.batch_mark_as_deleted("email", kwargs={"inbox_id": self.instance.id})
             chain(
                 tasks.inbox_new_flag.si(self.instance.user_id, self.instance.id),
                 tasks.batch_delete_items.si("email", kwargs={'inbox_id': self.instance.id, "deleted": True}),

--- a/inboxen/forms/inbox.py
+++ b/inboxen/forms/inbox.py
@@ -19,6 +19,7 @@
 
 import random
 
+from celery import chain
 from django import forms
 from django.contrib import messages
 from django.utils.translation import ugettext as _
@@ -99,7 +100,10 @@ class InboxEditForm(forms.ModelForm):
         if clear_inbox:
             emails = self.instance.email_set.all()
             emails.update(deleted=True)
-            tasks.batch_delete_items.delay("email", kwargs={'inbox__id': self.instance.id})
+            chain(
+                tasks.inbox_new_flag.si(self.instance.user_id, self.instance.id),
+                tasks.batch_delete_items.si("email", kwargs={'inbox_id': self.instance.id, "deleted": True}),
+            ).apply_async()
             warn_msg = _("All emails in {0}@{1} are being deleted.").format(self.instance.inbox,
                                                                             self.instance.domain.domain)
             messages.warning(self.request, warn_msg)

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -39,6 +39,10 @@ INBOX_CHOICES = string.ascii_lowercase
 # email has to be before it will be considered for delition
 INBOX_AUTO_DELETE_TIME = 30
 
+# Pagination
+INBOX_PAGE_SIZE = 25
+HOME_PAGE_SIZE = 25
+
 ##
 # To override the following settings, create a separate settings module.
 # Import this module, override what you need to and set the environment

--- a/inboxen/views/home.py
+++ b/inboxen/views/home.py
@@ -18,6 +18,7 @@
 ##
 
 
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponseNotAllowed, HttpResponseRedirect
 from django.views import generic
@@ -34,7 +35,7 @@ class UserHomeView(LoginRequiredMixin, SearchMixin, generic.ListView):
     """ The user's home which lists the inboxes """
     allow_empty = True
     model = models.Inbox
-    paginate_by = 25
+    paginate_by = settings.HOME_PAGE_SIZE
     template_name = "inboxen/home.html"
 
     def get_queryset(self):

--- a/inboxen/views/inbox/inbox.py
+++ b/inboxen/views/inbox/inbox.py
@@ -17,6 +17,7 @@
 #    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.http import Http404, HttpResponseNotAllowed, HttpResponseRedirect
@@ -36,7 +37,7 @@ __all__ = ["FormInboxView", "UnifiedInboxView", "SingleInboxView"]
 class InboxView(LoginRequiredMixin, SearchMixin, generic.ListView):
     """Base class for Inbox views"""
     model = models.Email
-    paginate_by = 25
+    paginate_by = settings.INBOX_PAGE_SIZE
     template_name = 'inboxen/inbox/inbox.html'
 
     def get_success_url(self):

--- a/inboxen/views/inbox/inbox.py
+++ b/inboxen/views/inbox/inbox.py
@@ -28,7 +28,7 @@ from inboxen import models
 from inboxen.search.tasks import search_single_inbox, search_unified_inbox
 from inboxen.search.utils import create_search_cache_key
 from inboxen.search.views import SearchMixin
-from inboxen.tasks import deal_with_flags, delete_inboxen_item
+from inboxen.tasks import delete_inboxen_item, set_emails_to_seen
 from inboxen.utils.tasks import task_group_skew
 
 __all__ = ["FormInboxView", "UnifiedInboxView", "SingleInboxView"]
@@ -134,7 +134,7 @@ class InboxView(LoginRequiredMixin, SearchMixin, generic.ListView):
         if inbox is not None:
             inbox = inbox.id
 
-        deal_with_flags.delay(object_id_list, self.request.user.id, inbox)
+        set_emails_to_seen.delay(object_id_list, self.request.user.id, inbox)
         return context
 
 


### PR DESCRIPTION
The following tasks have been updated to allow inbox flags to be set correctly

* empty inbox
* quota delete
* auto delete

Fixes #391 