### PR TITLE
last_login to be updated every time a session is extended

### DIFF
--- a/inboxen/middleware.py
+++ b/inboxen/middleware.py
@@ -19,6 +19,7 @@
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.signals import user_logged_in
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import ugettext as _
@@ -49,6 +50,11 @@ class ExtendSessionMiddleware(MiddlewareMixin):
                 request.session.cycle_key()
                 request.session.set_expiry(settings.SESSION_COOKIE_AGE)
                 request.session.modified = True
+                user_logged_in.send(
+                    sender=request.user.__class__,
+                    request=request,
+                    user=request.user,
+                )
 
 
 class MakeXSSFilterChromeSafeMiddleware(MiddlewareMixin):

--- a/inboxen/tests/test_misc.py
+++ b/inboxen/tests/test_misc.py
@@ -208,6 +208,21 @@ class ExtendSessionMiddlewareTestCase(InboxenTestCase):
         self.middleware.process_request(request)
         self.assertEqual(request.session.session_key, session_key)
 
+    def test_last_login(self):
+        user = factories.UserFactory()
+        request = MockRequest(user)
+
+        # no change, so no last_login
+        self.middleware.process_request(request)
+        user.refresh_from_db()
+        self.assertEqual(user.last_login, None)
+
+        # session is cycled
+        request.session.set_expiry(dj_settings.SESSION_COOKIE_AGE * 0.25)
+        self.middleware.process_request(request)
+        user.refresh_from_db()
+        self.assertNotEqual(user.last_login, None)
+
     def test_with_anon(self):
         user = AnonymousUser()
         request = MockRequest(user)


### PR DESCRIPTION
Otherwise a user could have a months long session but it would look like they never log in.

Required for #444