### PR TITLE
config: cache should be filesystem cache by default

### DIFF
--- a/inboxen/config.py
+++ b/inboxen/config.py
@@ -173,14 +173,7 @@ CACHES = {
     }
 }
 
-if config["cache"]["backend"] == "file":
-    if config["cache"]["location"] == "":
-        # sane default for minimum configuration
-        CACHES["default"]["LOCATION"] = os.path.join(os.getcwd(), "inboxen_cache")
-    else:
-        CACHES["default"]["LOCATION"] = os.path.join(os.getcwd(), config["cache"]["location"])
-else:
-    CACHES["default"]["LOCATION"] = config["cache"]["location"]
+CACHES["default"]["LOCATION"] = config["cache"]["location"]
 
 # populate __all__
 __all__ = [item for item in dir() if item.isupper()]

--- a/inboxen/config_defaults.yaml
+++ b/inboxen/config_defaults.yaml
@@ -1,8 +1,8 @@
 admins: []
 allowed_hosts: []
 cache:
-  backend: "django.core.cache.backends.db.DatabaseCache"
-  location: ""
+  backend: "django.core.cache.backends.filebased.FileBasedCache"
+  location: "inboxen_cache"
   timeout: 300
 database:
     host: ""


### PR DESCRIPTION
Database cache requires additional configuration that is not obvious
(i.e. Django doesn't tell you to run the createcachetable command)

fixes #517