### PR TITLE
Grunt staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,23 +2,24 @@
 docs/_build
 
 # inboxen specific
+/celery.log
 /celerybeat-schedule
 /celerybeat.pid
 /celeryd.pid
-/celery.log
+/docs/logs
+/docs/run
 /env
 /env3
+/inboxen.config
+/inboxen/static/compiled
 /inboxen_cache
 /liberation_store
 /logs
-/run
-/docs/logs
-/docs/run
-/settings.ini
-/inboxen.config
-/static_content
 /media_content
 /node_modules
+/run
+/settings.ini
+/static_content
 
 # local requirements
 /local-reqs.txt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,12 +5,13 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON("package.json"),
         dirs: {
             build: "frontend/build",
-            thirdparty: "node_modules",
-            js: "frontend/js",
             css: "frontend/css",
+            js: "frontend/js",
+            static: "inboxen/static/compiled",
+            thirdparty: "node_modules",
         },
         clean: {
-            build: ["<%= dirs.build %>"],
+            build: ["<%= dirs.build %>", "<%= dirs.static %>"],
         },
         copy: {
             fonts: {
@@ -18,12 +19,12 @@ module.exports = function(grunt) {
                 nonull: true,
                 flatten: true,
                 src: "<%= dirs.thirdparty %>/font-awesome/fonts/*",
-                dest: "<%= dirs.build %>/compiled/fonts/"
+                dest: "<%= dirs.static %>/fonts/",
             }
         },
         concat: {
             options: {
-                sourceMap: true
+                sourceMap: true,
             },
             website: {
                 src: [
@@ -63,11 +64,11 @@ module.exports = function(grunt) {
             },
             website: {
                 src: ["<%= dirs.build %>/src/website.js"],
-                dest: "<%= dirs.build %>/compiled/website.min.js"
+                dest: "<%= dirs.static %>/website.min.js"
             },
             stats: {
                 src: ["<%= dirs.build %>/src/stats.js"],
-                dest: "<%= dirs.build %>/compiled/stats.min.js"
+                dest: "<%= dirs.static %>/stats.min.js"
             }
         },
         sass: {
@@ -81,7 +82,7 @@ module.exports = function(grunt) {
             },
             publicCss: {
                 src: ["<%= dirs.css %>/inboxen.scss"],
-                dest: "<%= dirs.build %>/compiled/website.css"
+                dest: "<%= dirs.static %>/website.css"
             }
         },
         karma: {

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
+graft inboxen
 include LICENSE
 include versioneer.py
-exclude __pycache__
-exclude *.pyc
-exclude *.pyo
 
-graft inboxen
-
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/inboxen/settings.py
+++ b/inboxen/settings.py
@@ -141,10 +141,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
 
-STATICFILES_DIRS = [
-        os.path.join(os.getcwd(), "frontend", "build", "compiled"),
-]
-
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',

--- a/inboxen/templates/inboxen/base.html
+++ b/inboxen/templates/inboxen/base.html
@@ -8,7 +8,7 @@
         <meta http-equiv="Content-type" content="text/html;charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <link href="{% static "website.css" %}" rel="stylesheet" type="text/css" />
+        <link href="{% static "compiled/website.css" %}" rel="stylesheet" type="text/css" />
         {% block header %}{% endblock %}
     </head>
     <body>
@@ -77,7 +77,7 @@
             </div>
         {% endblock %}
         </div>
-        <script src="{% static "website.min.js" %}"></script>
+        <script src="{% static "compiled/website.min.js" %}"></script>
         {% block extra_js %}{% endblock %}
     </body>
 </html>

--- a/inboxen/templates/inboxen/stats.html
+++ b/inboxen/templates/inboxen/stats.html
@@ -5,7 +5,7 @@
 {% block headline %}{% trans "Server Statistics" %}{% endblock %}
 
 {% block extra_js %}
-    <script src="{% static "stats.min.js" %}"></script>
+    <script src="{% static "compiled/stats.min.js" %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/inboxen/templates/inboxen/styleguide.html
+++ b/inboxen/templates/inboxen/styleguide.html
@@ -8,7 +8,7 @@
         <meta http-equiv="Content-type" content="text/html;charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <link href="{% static "website.css" %}" rel="stylesheet" type="text/css" />
+        <link href="{% static "compiled/website.css" %}" rel="stylesheet" type="text/css" />
         {% block header %}{% endblock %}
     </head>
     <body>


### PR DESCRIPTION
Tell grunt to place compiled static files into `inboxen/static`.

In future we will be releasing Inboxen as a proper Python package rather than the mess we have right now. This change means `sdist` picks up compiled static files and Django's `collectstatic` will be able to find them too.