### PR TITLE
disowned command

### DIFF
--- a/inboxen/management/commands/disowned.py
+++ b/inboxen/management/commands/disowned.py
@@ -1,0 +1,39 @@
+##
+#    Copyright (C) 2020 Jessica Tallon & Matt Molyneaux
+#
+#    This file is part of Inboxen.
+#
+#    Inboxen is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Inboxen is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with Inboxen.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+from django.core.management.base import BaseCommand
+
+from inboxen.models import Inbox
+
+
+class Command(BaseCommand):
+    help = "Print a list of disowned Inboxes. For use with Internet facing mail servers."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--postfix", action="store_true", help="Format output for use with Postfix")
+
+    def handle(self, **options):
+        tmpl = "{}\n"
+        if options["postfix"]:
+            tmpl = "{}\t501 5.1.1 Address no longer in use\n"
+
+        for inbox in Inbox.objects.disowned().order_by("id"):
+            self.stdout.write(tmpl.format(str(inbox)))
+
+        self.stdout.flush()

--- a/inboxen/managers.py
+++ b/inboxen/managers.py
@@ -115,6 +115,9 @@ class InboxQuerySet(SearchQuerySet):
         qs = self.filter(user=user)
         return qs.exclude(deleted=True)
 
+    def disowned(self):
+        return self.filter(user__isnull=True)
+
     def add_last_activity(self):
         """Annotates `last_activity` onto each Inbox and then orders by that column"""
         qs = self.annotate(last_activity=Coalesce(Max("email__received_date",

--- a/inboxen/tests/test_misc.py
+++ b/inboxen/tests/test_misc.py
@@ -403,6 +403,24 @@ class CreateDomainCommandTestCase(InboxenTestCase):
             call_command("createdomain", "localhost1")
 
 
+class DisownedCommandTestCase(InboxenTestCase):
+    def setUp(self):
+        user = factories.UserFactory()
+        self.owned_inboxes = factories.InboxFactory.create_batch(3, user=user)
+        self.disowned_inboxes = factories.InboxFactory.create_batch(3, user=None)
+
+    def test_without_args(self):
+        stdout = StringIO()
+        call_command("disowned", stdout=stdout)
+        self.assertEqual(stdout.getvalue(), "".join(["{}\n".format(i) for i in self.disowned_inboxes]))
+
+    def test_postfix(self):
+        stdout = StringIO()
+        call_command("disowned", "--postfix", stdout=stdout)
+        self.assertEqual(stdout.getvalue(), "".join(["{}\t501 5.1.1 Address no longer in use\n".format(i)
+                                                     for i in self.disowned_inboxes]))
+
+
 class ErrorViewTestCase(InboxenTestCase):
     def test_view(self):
         view_func = ErrorView.as_view(

--- a/inboxen/tests/test_models.py
+++ b/inboxen/tests/test_models.py
@@ -185,6 +185,14 @@ class ModelTestCase(InboxenTestCase):
         count = models.Inbox.objects.viewable(user).count()
         self.assertEqual(count, 2)
 
+    def test_inbox_disowned(self):
+        factories.InboxFactory(user=factories.UserFactory())
+        disowned = factories.InboxFactory(user=None)
+
+        qs = models.Inbox.objects.disowned()
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(qs[0].id, disowned.id)
+
     def test_email_viewable(self):
         user = factories.UserFactory()
         other_user = factories.UserFactory(username="lalna")


### PR DESCRIPTION
List disowned Inboxes. Useful for Internet facing mail servers. We can
remove this when/if Salmon ever becomes capable of being Internet facing
in a safe manner.